### PR TITLE
Removed setfacl. Using SETGID bit instead

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -66,7 +66,7 @@ RUN sed -i "s@^listen = 127.0.0.1:9000@listen = $PORT@" /usr/local/etc/php-fpm.d
  && sed -i "s@^user = nobody@user = www-data@" /usr/local/etc/php-fpm.d/www.conf.default \
  && sed -i "s@^group = nobody@group = www-data@" /usr/local/etc/php-fpm.d/www.conf.default
 
-RUN groupadd -g 10000 ez && useradd -g ez -u 10000 ez --create-home
+RUN groupadd -g 10000 ez && useradd -g ez -G www-data -u 10000 ez --create-home && echo "umask 0002" >> /etc/bash.bashrc
 # Create Composer directory (cache and auth files)
 RUN mkdir -p $COMPOSER_HOME && chown ez:ez $COMPOSER_HOME
 
@@ -80,6 +80,7 @@ ADD prepare_distribution_volume.sh /prepare_distribution_volume.sh
 ADD prepare_behat.sh /prepare_behat.sh
 ADD default_mysql_settings.sh /default_mysql_settings.sh
 ADD wait_for_db.sh /wait_for_db.sh
+ADD set_permissions.sh /set_permissions.sh
 
 #/usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 #ADD config/opcache.ini /usr/local/php7/etc/conf.d/opcache.ini

--- a/php/prepare_distribution_volume.sh
+++ b/php/prepare_distribution_volume.sh
@@ -28,14 +28,14 @@ function getIndexScript
 function set_splash_screen
 {
     if [ ! -f "${INDEX_SCRIPT}.org" ]; then
-        sudo -u ez mv ${INDEX_SCRIPT} ${INDEX_SCRIPT}.org
+        mv ${INDEX_SCRIPT} ${INDEX_SCRIPT}.org
     fi
-    sudo -u ez echo "<html><body>$1</body></html>" > ${INDEX_SCRIPT}
+    echo "<html><body>$1</body></html>" > ${INDEX_SCRIPT}
 }
 
 function remove_splash_screen
 {
-    sudo -u ez mv ${INDEX_SCRIPT}.org ${INDEX_SCRIPT}
+    mv ${INDEX_SCRIPT}.org ${INDEX_SCRIPT}
 }
 
 function import_database
@@ -64,7 +64,7 @@ function import_database
         let TRY=$TRY+1
         if [ $TRY -eq $MAXTRY ]; then
             echo Max limit reached. Not able to connect to mysql
-            sudo -u ez rm /tmp/prepare_distribution_already_run.txt
+            rm /tmp/prepare_distribution_already_run.txt
             exit 1;
         fi
         sleep 5;

--- a/php/prepare_distribution_volume.sh
+++ b/php/prepare_distribution_volume.sh
@@ -38,30 +38,6 @@ function remove_splash_screen
     sudo -u ez mv ${INDEX_SCRIPT}.org ${INDEX_SCRIPT}
 }
 
-function set_permissions
-{
-    if [ "aa$APACHE_RUN_USER" == "aa" ]; then
-        APACHE_RUN_USER=www-data
-    fi
-
-    if [ ! -d web/var ]; then
-        sudo -u ez mkdir web/var
-    fi
-
-    if [ -d ezpublish ]; then
-        setfacl -R -m u:$APACHE_RUN_USER:rwX -m u:ez:rwX ezpublish/{cache,logs,sessions} web/var
-        setfacl -dR -m u:$APACHE_RUN_USER:rwX -m u:ez:rwX ezpublish/{cache,logs,sessions} web/var
-    else
-        setfacl -R -m u:$APACHE_RUN_USER:rwX -m u:ez:rwX app/{cache,logs} web/var
-        setfacl -dR -m u:$APACHE_RUN_USER:rwX -m u:ez:rwX app/{cache,logs} web/var
-    fi
-
-    if [ -d ezpublish_legacy ]; then
-        setfacl -R -m u:$APACHE_RUN_USER:rwx -m u:ez:rwx ezpublish_legacy/{design,extension,settings,var} ezpublish/config web
-        setfacl -dR -m u:$APACHE_RUN_USER:rwx -m u:ez:rwx ezpublish_legacy/{design,extension,settings,var} ezpublish/config web
-    fi
-}
-
 function import_database
 {
     local DBUP
@@ -106,8 +82,6 @@ function warm_cache
 
 prevent_multiple_execuition
 getIndexScript
-set_splash_screen "Initializing"
-set_permissions
 set_splash_screen "Waiting for db connection"
 import_database
 

--- a/php/run.sh
+++ b/php/run.sh
@@ -57,19 +57,6 @@ if [ ! -d web/var ] && [ "$SKIP_INITIALIZING_VAR" == "false" ]; then
     sudo -u ez mkdir web/var
 fi
 
-if [ -d ezpublish ]; then
-    setfacl -R -m u:$APACHE_RUN_USER:rwX -m u:ez:rwX ezpublish/{cache,logs,sessions}${VARDIR}
-    setfacl -dR -m u:$APACHE_RUN_USER:rwX -m u:ez:rwX ezpublish/{cache,logs,sessions}${VARDIR}
-else
-    setfacl -R -m u:$APACHE_RUN_USER:rwX -m u:ez:rwX app/{cache,logs}${VARDIR}
-    setfacl -dR -m u:$APACHE_RUN_USER:rwX -m u:ez:rwX app/{cache,logs}${VARDIR}
-fi
-
-if [ -d ezpublish_legacy ]; then
-    setfacl -R -m u:$APACHE_RUN_USER:rwx -m u:ez:rwx ezpublish_legacy/{design,extension,settings,var} ezpublish/config web
-    setfacl -dR -m u:$APACHE_RUN_USER:rwx -m u:ez:rwx ezpublish_legacy/{design,extension,settings,var} ezpublish/config web
-fi
-
 APP_FOLDER="app"
 if [ -d ezpublish ]; then
     APP_FOLDER="ezpublish"
@@ -85,6 +72,8 @@ sudo -u ez php $APP_FOLDER/console assets:install --symlink --relative --env $EZ
 if [ -d ezpublish_legacy ]; then
     sudo -u ez php $APP_FOLDER/console ezpublish:legacy:assets_install --symlink --relative --env $EZ_ENVIRONMENT
 fi
+
+umask 0002
 
 # Start php-fpm
 if [ -x /usr/local/sbin/php-fpm ]; then

--- a/php/set_permissions.sh
+++ b/php/set_permissions.sh
@@ -117,19 +117,35 @@ function set_permissions_prod
 
 function set_permissions_www_data
 {
+    local APP_FOLDER
+    APP_FOLDER="app"
+
+    # eZ Publish 5.4 stuff
+    if [ -d ezpublish ]; then
+        APP_FOLDER="ezpublish"
+    fi
+
+    # You might set SKIP_INITIALIZING_VAR=true if you would like to setup web/var from outside this container
+    if [ "$SKIP_INITIALIZING_VAR" == "true" ]; then
+        VARDIR=""
+    else
+        SKIP_INITIALIZING_VAR="false"
+        VARDIR="web/var"
+    fi
+
     if [ ! -d web/var ]; then
         mkdir web/var
     fi
 
-    if [ -d ezpublish ]; then
-        find {ezpublish/{cache,logs,sessions},web/var} -type d | xargs --no-run-if-empty chmod -R 2775
-        find {ezpublish/{cache,logs,sessions},web/var} -type f | xargs --no-run-if-empty chmod -R 664
-        chown :$APACHE_RUN_USER -R {ezpublish/{cache,logs,sessions},web/var}
-    else
-        find {app/{cache,logs},web/var} -type d | xargs --no-run-if-empty chmod -R 2775
-        find {app/{cache,logs},web/var} -type f | xargs --no-run-if-empty chmod -R 664
-        chown :$APACHE_RUN_USER -R {app/{cache,logs},web/var}
+    # eZ Publish 5.4 stuff
+    if [ -d ezpublish/sessions ]; then
+        find ezpublish/sessions -type d | xargs --no-run-if-empty chmod -R 2775
+        find ezpublish/sessions -type f | xargs --no-run-if-empty chmod -R 664
+        chown :$APACHE_RUN_USER -R ezpublish/sessions
     fi
+    find ${APP_FOLDER}/{cache,logs} ${VARDIR} -type d | xargs --no-run-if-empty chmod -R 2775
+    find ${APP_FOLDER}/{cache,logs} ${VARDIR} -type f | xargs --no-run-if-empty chmod -R 664
+    chown :$APACHE_RUN_USER -R ${APP_FOLDER}/{cache,logs} ${VARDIR}
 
 
     if [ -d ezpublish_legacy ]; then

--- a/php/set_permissions.sh
+++ b/php/set_permissions.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+set -e
+
+PARAM_WWW_DATA="true"
+PARAM_DEV="false"
+PARAM_PROD="false"
+
+if [ "$APACHE_RUN_USER" == "" ]; then
+    APACHE_RUN_USER=www-data
+fi
+
+
+function usage
+{
+    # General help text
+    cat << EOF
+Script for setting ownership and permissions inside eZ Platform containers
+
+Help (this text):
+/set_permissions.sh [-h|--help]
+
+Usage:
+/set_permissions.sh [ options ]...
+
+
+Options:
+  [--www-data]       : Set permission and ownership of the files the web server needs write access to ( var/web/www, app/cache etc )
+                       If no other options are given, this is the default action
+  [--dev]            : Set permission and ownership for development use. All source files will to be writable by ez user.
+  [--prod]           : Set permission and ownership for production use. All source files to be owned by root.
+  [-h|--help]        : This help screen
+
+EOF
+}
+
+
+function parse_commandline_arguments
+{
+    # Based on http://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash, comment by Shane Day answered Jul 1 '14 at 1:20
+    while [ -n "$1" ]; do
+        # Copy so we can modify it (can't modify $1)
+        OPT="$1"
+        # Detect argument termination
+        if [ x"$OPT" = x"--" ]; then
+            shift
+            for OPT ; do
+                REMAINS="$REMAINS \"$OPT\""
+            done
+            break
+        fi
+        # Parse current opt
+        while [ x"$OPT" != x"-" ] ; do
+            case "$OPT" in
+                # Handle --flag=value opts like this
+                -h | --help )
+                    usage
+                    exit 0
+                    ;;
+                --www-data )
+                    PARAM_WWW_DATA="true"
+                    ;;
+                --dev )
+                    PARAM_DEV="true"
+                    ;;
+                --prod )
+                    PARAM_PROD="true"
+                    ;;
+                # Anything unknown is recorded for later
+                * )
+                    REMAINS="$REMAINS \"$OPT\""
+                    break
+                    ;;
+            esac
+            # Check for multiple short options
+            # NOTICE: be sure to update this pattern to match valid options
+            NEXTOPT="${OPT#-[st]}" # try removing single short opt
+            if [ x"$OPT" != x"$NEXTOPT" ] ; then
+                OPT="-$NEXTOPT"  # multiple short opts, keep going
+            else
+                break  # long form, exit inner loop
+            fi
+        done
+        # Done with that param. move to next
+        shift
+    done
+    # Set the non-parameters back into the positional parameters ($1 $2 ..)
+    eval set -- $REMAINS
+}
+
+function validate_commandline_arguments
+{
+    if [ "$PARAM_DEV" == "true" ] && [ "$PARAM_PROD" == "true" ]; then
+        usage
+        echo "Error : You cannot provide both --dev and --prod at the same time"
+    fi
+}
+
+function set_permissions_dev
+{
+    if [ "$PARAM_DEV" == "true" ]; then
+        chmod g+w -R /var/www
+        find /var/www -type d -exec chmod 2775 {} ';'
+        chown ez:ez -R /var/www
+        chown root -R /var/www/web/var
+    fi
+}
+
+function set_permissions_prod
+{
+    if [ "$PARAM_PROD" == "true" ]; then
+        chmod g-w -R /var/www
+        find /var/www -type d -exec chmod a-w,g-s,a+rx,u+w {} ';'
+        chown root:root -R /var/www
+    fi
+}
+
+function set_permissions_www_data
+{
+    if [ ! -d web/var ]; then
+        mkdir web/var
+    fi
+
+    if [ -d ezpublish ]; then
+        find {ezpublish/{cache,logs,sessions},web/var} -type d | xargs --no-run-if-empty chmod -R 2775
+        find {ezpublish/{cache,logs,sessions},web/var} -type f | xargs --no-run-if-empty chmod -R 664
+        chown :$APACHE_RUN_USER -R {ezpublish/{cache,logs,sessions},web/var}
+    else
+        find {app/{cache,logs},web/var} -type d | xargs --no-run-if-empty chmod -R 2775
+        find {app/{cache,logs},web/var} -type f | xargs --no-run-if-empty chmod -R 664
+        chown :$APACHE_RUN_USER -R {app/{cache,logs},web/var}
+    fi
+
+
+    if [ -d ezpublish_legacy ]; then
+        find ezpublish_legacy/{design,extension,settings,var} -type d | xargs --no-run-if-empty chmod -R 2775
+        find ezpublish_legacy/{design,extension,settings,var} -type f | xargs --no-run-if-empty chmod -R 664
+        chown :$APACHE_RUN_USER -R ezpublish_legacy/{design,extension,settings,var}
+    fi
+
+    # Workaround as long as installer needs write access to config/
+    if [ -d app/config ]; then
+        chown :$APACHE_RUN_USER -R app/config
+        chmod 2775 app/config
+        chmod 664 app/config/*
+    elif [ -d ezpublish/config ]; then
+        chown :$APACHE_RUN_USER -R ezpublish/config
+        chmod 2775 ezpublish/config
+        chmod 664 ezpublish/config/*
+    fi
+
+}
+
+parse_commandline_arguments "$@"
+validate_commandline_arguments
+
+
+cd /var/www
+set_permissions_dev
+set_permissions_prod
+set_permissions_www_data
+cd - > /dev/null


### PR DESCRIPTION
Removed setfacl for the following reasons:
- Doesn't work with nfs ( if you want to put vardir on nfs for instance )
- Not all union file systems ( if any at all ) supports facls, thus making it impossible to store final file permissions in docker images

cons:
- User on host has to manually add himself to group 10000 and set umask 0002 if he wants to change code etc
