### PR TITLE
Simplify persmissions, remove ez user

### DIFF
--- a/bin/.travis/test.sh
+++ b/bin/.travis/test.sh
@@ -37,7 +37,7 @@ if [ "$REUSE_VOLUME" = "0" ]; then
     docker run -ti --rm \
       -e SYMFONY_ENV \
       -v $(pwd)/volumes/ezplatform:/var/www \
-      -v  $COMPOSER_HOME:/home/ez/.composer \
+      -v  $COMPOSER_HOME:/root/.composer \
       ez_php:latest \
       bash -c "composer create-project --no-dev --prefer-dist --no-progress --no-interaction ezsystems/ezplatform /var/www"
 fi

--- a/bin/.travis/test.sh
+++ b/bin/.travis/test.sh
@@ -34,7 +34,7 @@ if [ "$REUSE_VOLUME" = "0" ]; then
     fi
 
     printf "\nBuilding on ez_php:latest, composer will implicit check requirements\n"
-    docker run -ti --rm --user=ez \
+    docker run -ti --rm \
       -e SYMFONY_ENV \
       -v $(pwd)/volumes/ezplatform:/var/www \
       -v  $COMPOSER_HOME:/home/ez/.composer \
@@ -45,14 +45,14 @@ fi
 
 
 printf "\nMinimal testing on ez_php:latest for use with ez user"
-docker run -ti --rm --user=ez \
+docker run -ti --rm \
   -v $(pwd)/volumes/ezplatform:/var/www \
   -v $(pwd)/bin/.travis/testSymfonyRequirements.php:/var/www/testSymfonyRequirements.php \
   ez_php:latest \
   bash -c "php testSymfonyRequirements.php"
 
 printf "\nMinimal testing on ez_php:latest-dev for use with ez user"
-docker run -ti --rm --user=ez \
+docker run -ti --rm \
   -v $(pwd)/volumes/ezplatform:/var/www \
   -v $(pwd)/bin/.travis/testSymfonyRequirements.php:/var/www/testSymfonyRequirements.php \
   ez_php:latest-dev \

--- a/php/Dockerfile-5.5
+++ b/php/Dockerfile-5.5
@@ -13,7 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     MEMORY_LIMIT=256M \
     MAX_EXECUTION_TIME=90 \
     PORT=9000 \
-    COMPOSER_HOME=/home/ez/.composer
+    COMPOSER_HOME=/root/.composer
 
 ## Get packages
 ### unzip needed due to https://github.com/composer/composer/issues/4471
@@ -58,10 +58,8 @@ COPY config/blackfire.ini ${PHP_INI_DIR}/conf.d/blackfire.ini
 # Add pid file to be able to restart php-fpm
 RUN sed -i "s@^\[global\]@\[global\]\n\npid = /run/php-fpm.pid@" ${PHP_INI_DIR}-fpm.conf
 
-RUN groupadd -g 10000 ez && useradd -g ez -G www-data -u 10000 ez --create-home && echo "umask 0002" >> /etc/bash.bashrc
-
 # Create Composer directory (cache and auth files)
-RUN mkdir -p $COMPOSER_HOME && chown ez:ez $COMPOSER_HOME
+RUN mkdir -p $COMPOSER_HOME
 
 # Get Composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/php/Dockerfile-5.6
+++ b/php/Dockerfile-5.6
@@ -13,7 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     MEMORY_LIMIT=256M \
     MAX_EXECUTION_TIME=90 \
     PORT=9000 \
-    COMPOSER_HOME=/home/ez/.composer
+    COMPOSER_HOME=/root/.composer
 
 ## Get packages
 ### unzip needed due to https://github.com/composer/composer/issues/4471
@@ -58,10 +58,8 @@ COPY config/blackfire.ini ${PHP_INI_DIR}/conf.d/blackfire.ini
 # Add pid file to be able to restart php-fpm
 RUN sed -i "s@^\[global\]@\[global\]\n\npid = /run/php-fpm.pid@" ${PHP_INI_DIR}-fpm.conf
 
-RUN groupadd -g 10000 ez && useradd -g ez -G www-data -u 10000 ez --create-home && echo "umask 0002" >> /etc/bash.bashrc
-
 # Create Composer directory (cache and auth files)
-RUN mkdir -p $COMPOSER_HOME && chown ez:ez $COMPOSER_HOME
+RUN mkdir -p $COMPOSER_HOME
 
 # Get Composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/php/Dockerfile-7.0
+++ b/php/Dockerfile-7.0
@@ -13,7 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     MEMORY_LIMIT=256M \
     MAX_EXECUTION_TIME=90 \
     PORT=9000 \
-    COMPOSER_HOME=/home/ez/.composer
+    COMPOSER_HOME=/root/.composer
 
 ## Get packages
 ### unzip needed due to https://github.com/composer/composer/issues/4471
@@ -58,10 +58,8 @@ COPY config/blackfire.ini ${PHP_INI_DIR}/conf.d/blackfire.ini
 # Add pid file to be able to restart php-fpm
 RUN sed -i "s@^\[global\]@\[global\]\n\npid = /run/php-fpm.pid@" ${PHP_INI_DIR}-fpm.conf
 
-RUN groupadd -g 10000 ez && useradd -g ez -u 10000 ez --create-home
-
 # Create Composer directory (cache and auth files)
-RUN mkdir -p $COMPOSER_HOME && chown ez:ez $COMPOSER_HOME
+RUN mkdir -p $COMPOSER_HOME
 
 # Get Composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/php/scripts/prepare_distribution_volume.sh
+++ b/php/scripts/prepare_distribution_volume.sh
@@ -10,7 +10,7 @@ prevent_multiple_execution()
         echo "Script has already been executed. Bailling out"
         exit
     fi
-    sudo -u ez touch /tmp/prepare_distribution_already_run.txt
+    sudo touch /tmp/prepare_distribution_already_run.txt
 }
 
 # $1 is description

--- a/php/scripts/run.sh
+++ b/php/scripts/run.sh
@@ -38,26 +38,13 @@ if [ "$EZ_KICKSTART_TEMPLATE" != "" ]; then
 fi
 
 if [ "$DEV_MODE" = "true" ]; then
-    APP_FOLDER="app"
-
-    # EZP5: By default app folder is "app", but "ezpublish" is selected if found for bc.
-    if [ -d ezpublish ]; then
-        APP_FOLDER="ezpublish"
-    fi
-
     if [ ! -d web/var ]; then
         echo "Creating web/var as it was missing"
-        sudo -u ez mkdir -m 2775 web/var
+        mkdir -m 2775 web/var && chown www-data -R web/var
     fi
 
-    echo "Clearing cache '$APP_FOLDER/cache/*/*' to make sure env variables are taken into account for env settings"
-    rm -Rf $APP_FOLDER/cache/*/*
-
-    # Will set ez as owner of the newly generated files
-    /scripts/set_permissions.sh --dev
-else
-    # Todo: Remove, should not be needed in prod where permissions are set on image (but depends on removal of ez user)
-    /scripts/set_permissions.sh
+    # Needed for docker-machine
+    usermod -u 1000 www-data
 fi
 
 # Start php-fpm

--- a/php/scripts/set_permissions.sh
+++ b/php/scripts/set_permissions.sh
@@ -1,126 +1,17 @@
 #!/usr/bin/env sh
+# Sets dev permissions using ACL, not really used anymore
 
 set -e
 
-PARAM_DEV="false"
-PARAM_IMMUTABLE="false"
-
-usage()
-{
-    # General help text
-    cat << EOF
-Script for setting ownership and permissions inside eZ Platform containers
-
-By default set permission and ownership of the files the web server needs write access to ( var/web/www, app/cache etc ).
-With options additional rights on the whole installation can be set as well.
-
-Help (this text):
-/set_permissions.sh [-h|--help]
-
-Usage:
-/set_permissions.sh [ options ]...
-
-Options:
-
-  [--dev]            : Set permission and ownership for development use. All source files will to be writable by ez user.
-  [--immutable]      : Set permission and ownership for immutable production use. All source files to be owned by root.
-  [-h|--help]        : This help screen
-
-EOF
-}
-
-
-parse_commandline_arguments()
-{
-    # Based on http://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash, comment by Shane Day answered Jul 1 '14 at 1:20
-    while [ -n "$1" ]; do
-        # Copy so we can modify it (can't modify $1)
-        OPT="$1"
-        # Detect argument termination
-        if [ x"$OPT" = x"--" ]; then
-            shift
-            for OPT ; do
-                REMAINS="$REMAINS \"$OPT\""
-            done
-            break
-        fi
-        # Parse current opt
-        while [ x"$OPT" != x"-" ] ; do
-            case "$OPT" in
-                # Handle --flag=value opts like this
-                -h | --help )
-                    usage
-                    exit 0
-                    ;;
-                --dev )
-                    PARAM_DEV="true"
-                    ;;
-                --immutable )
-                    PARAM_IMMUTABLE="true"
-                    ;;
-                # Anything unknown is recorded for later
-                * )
-                    REMAINS="$REMAINS \"$OPT\""
-                    break
-                    ;;
-            esac
-            # Check for multiple short options
-            # NOTICE: be sure to update this pattern to match valid options
-            NEXTOPT="${OPT#-[st]}" # try removing single short opt
-            if [ x"$OPT" != x"$NEXTOPT" ] ; then
-                OPT="-$NEXTOPT"  # multiple short opts, keep going
-            else
-                break  # long form, exit inner loop
-            fi
-        done
-        # Done with that param. move to next
-        shift
-    done
-    # Set the non-parameters back into the positional parameters ($1 $2 ..)
-    eval set -- $REMAINS
-}
-
-validate_commandline_arguments()
-{
-    if [ "$PARAM_DEV" = "true" ] && [ "$PARAM_IMMUTABLE" = "true" ]; then
-        usage
-        echo "Error : You cannot provide both --dev and --immutable at the same time"
-    fi
-}
-
-set_permissions_dev()
-{
-    if [ "$PARAM_DEV" = "true" ]; then
-        chmod a+w -R /var/www
-        chown ez:ez -R /var/www
-    fi
-
-    # ezpublish 5.x needs access to write to config folder
-    if [ -d ezpublish/config ]; then
-        chown :www-data -R ezpublish/config
-        chmod 775 ezpublish/config
-        chmod 664 ezpublish/config/*
-    fi
-}
-
-set_permissions_immutable()
-{
-    if [ "$PARAM_IMMUTABLE" = "true" ]; then
-        chmod og-w -R /var/www
-        chown root:root -R /var/www
-    fi
-}
-
 set_permissions_www_data()
 {
-    local APP_FOLDER
-    APP_FOLDER="app"
-    if [ -d ezpublish ]; then
+    local APP_FOLDER="app"
+    if [ -d ezpublish ] &&  [ ! -d app ]; then
         APP_FOLDER="ezpublish"
     fi
 
     if [ ! -d web/var ]; then
-        sudo -u ez mkdir -m 2775 web/var
+        sudo -u www-data mkdir -m 2775 web/var
     fi
 
     # Support for cache and log dir being set by env var (you'll need to overload getCacheDir & getLogDir for this)
@@ -132,19 +23,25 @@ set_permissions_www_data()
         KERNEL_LOGS_DIR=${APP_FOLDER}/logs
     fi
 
-    setfacl -R -m u:www-data:rwX -m u:ez:rwX ${KERNEL_CACHE_DIR} ${KERNEL_LOGS_DIR} web/var
-    setfacl -dR -m u:www-data:rwX -m u:ez:rwX ${KERNEL_CACHE_DIR} ${KERNEL_LOGS_DIR} web/var
+    setfacl -R -m u:www-data:rwX ${KERNEL_CACHE_DIR} ${KERNEL_LOGS_DIR} web/var
+    setfacl -dR -m u:www-data:rwX ${KERNEL_CACHE_DIR} ${KERNEL_LOGS_DIR} web/var
 
     # eZ Publish 5.4 stuff
     if [ -d ezpublish/sessions ]; then
-        setfacl -R -m u:www-data:rwX -m u:ez:rwX ezpublish/sessions
-        setfacl -dR -m u:www-data:rwX -m u:ez:rwX ezpublish/sessions
+        setfacl -R -m u:www-data:rwX ezpublish/sessions
+        setfacl -dR -m u:www-data:rwX ezpublish/sessions
+    fi
+
+    # eZ Publish 5.x needs access to write to config folder
+    if [ -d ezpublish/config ]; then
+        setfacl -R -m u:www-data:rwX ezpublish/config
+        setfacl -dR -m u:www-data:rwX ezpublish/config
     fi
 
     # ezpublish-legacy stuff
     if [ -d ezpublish_legacy ]; then
-        setfacl -R -m u:www-data:rwX -m u:ez:rwX ezpublish_legacy/design ezpublish_legacy/extension ezpublish_legacy/settings ezpublish_legacy/var
-        setfacl -dR -m u:www-data:rwX -m u:ez:rwX ezpublish_legacy/design ezpublish_legacy/extension ezpublish_legacy/settings ezpublish_legacy/var
+        setfacl -R -m u:www-data:rwX ezpublish_legacy/design ezpublish_legacy/extension ezpublish_legacy/settings ezpublish_legacy/var
+        setfacl -dR -m u:www-data:rwX ezpublish_legacy/design ezpublish_legacy/extension ezpublish_legacy/settings ezpublish_legacy/var
     fi
 }
 
@@ -152,7 +49,5 @@ parse_commandline_arguments "$@"
 validate_commandline_arguments
 
 cd /var/www
-set_permissions_dev
-set_permissions_immutable
 set_permissions_www_data
 cd - > /dev/null


### PR DESCRIPTION
Having two users in same image makes things hard, especially when we
need to support dev setup where volume often don't support extended file
attributes needed for acl.

So we drop ez user, and from now on www-data is user to use for fpm server and command line. This implies images extending this sets rights correctly during build, and if you for some reason need to run composer update or otherwise recreate files and and folders www-data needs to have right access to, then you'll need to fix permissions afterwards.

This PR also strips out a few other magic things done in dev setup, as we rather try to set www-data to UID that gives her full rights when in dev.
