### PR TITLE
Add PHP 7.1 and update redis extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - FORMAT_VERSION="v1"
   matrix:
     # Run once per Dockerfile-<PHP_VERSION>
-    - PHP_VERSION="5.5"
+    - PHP_VERSION="5.5" EZ_VERSION="~1.6.0"
     - PHP_VERSION="5.6"
     - PHP_VERSION="7.0"
     - PHP_VERSION="7.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,14 @@ services:
 env:
   global:
     - REMOTE_IMAGE="ezsystems/php"
-    - LATEST="7.0"
+    - LATEST="7.1"
     - FORMAT_VERSION="v1"
   matrix:
     # Run once per Dockerfile-<PHP_VERSION>
     - PHP_VERSION="5.5"
     - PHP_VERSION="5.6"
     - PHP_VERSION="7.0"
+    - PHP_VERSION="7.1"
 
 before_script:
   - if [ ! -d ~/.composer/ ] ; then mkdir ~/.composer/; fi
@@ -25,6 +26,7 @@ before_script:
 script: bin/.travis/test.sh
 
 after_success: if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bin/.travis/push.sh ${REMOTE_IMAGE} ${FORMAT_VERSION}; fi
+
 after_failure: if [ -d volumes/ezplatform ]; then cd volumes/ezplatform; docker-compose logs; fi
 
 # test only master (+ Pull requests)

--- a/README.md
+++ b/README.md
@@ -20,15 +20,16 @@ PHP image that aims to technically support running:
 ## Images
 
 This repository contains several images for different versions of PHP\*:
-- [7.0](php/Dockerfile-7.0) *(Will become the recommend version)*
+- [7.1](php/Dockerfile-7.1) *(Recommended version for testing newest versions of eZ Platform)*
+- [7.0](php/Dockerfile-7.0)
 - [5.6](php/Dockerfile-5.6)
-- [5.5](php/Dockerfile-5.5) *(EOL, so only meant for compatibility testing for maintenance releases)*
+- [5.5](php/Dockerfile-5.5) *(EOL, so only meant for compatibility testing for older maintenance releases)*
 
 -\* *Primarily: Since this is also used to run functional testing against several PHP versions, for any other usage use the recommended image.*
 
 ### Dev image
 
-For each php version there is an addtional `-dev` flavour with addtional tools for when you need to be able to login and work towards the installation. It contains tools like vim, git, xdebug, ... [and others](php/Dockerfile-dev).
+For each php version there is an additional `-dev` flavour with additional tools for when you need to be able to login and work towards the installation. It contains tools like vim, git, xdebug, ... [and others](php/Dockerfile-dev).
 
 
 ### Format version
@@ -74,7 +75,7 @@ docker run --rm mycompany/myapp_volume app/console list
 
 ### Development use
 
-*Warning: As of May 2016, avoid using Docker for Mac beta for this setup, as it's load times are typically 60-90 seconds because of IO issues way worse then what Virtualbox ever had when doing shared folder. Which is essentially what is being used here when not on Linux, and when using what Docker calls host mounted volumes.*
+*Warning: As of December 2016, avoid using Docker for Mac beta for this setup, as it's load times are typically 60-90 seconds because of IO issues way worse then what Virtualbox ever had when doing shared folder. Which is essentially what is being used here when not on Linux, and when using what Docker calls host mounted volumes.*
 
 To get started, lets set permissions for dev use, and make sure to install composer packages:
 ```bash

--- a/bin/.travis/test.sh
+++ b/bin/.travis/test.sh
@@ -27,6 +27,11 @@ if [ "$FORMAT_VERSION" = "" ]; then
     FORMAT_VERSION="v1"
 fi
 
+if [ "$EZ_VERSION" = "" ]; then
+    EZ_VERSION="@alpha"
+fi
+
+
 if [ "$REUSE_VOLUME" = "0" ]; then
     printf "\n(Re-)Creating volumes/ezplatform for fresh checkout, needs sudo to delete old and chmod new folder\n"
     sudo rm -Rf volumes/ezplatform
@@ -43,7 +48,7 @@ if [ "$REUSE_VOLUME" = "0" ]; then
       -v $(pwd)/volumes/ezplatform:/var/www \
       -v  $COMPOSER_HOME:/root/.composer \
       ez_php:latest \
-      bash -c "composer create-project --prefer-dist --no-progress --no-interaction ezsystems/ezplatform /var/www @alpha"
+      bash -c "composer create-project --prefer-dist --no-progress --no-interaction ezsystems/ezplatform /var/www $EZ_VERSION"
 fi
 
 

--- a/bin/.travis/test.sh
+++ b/bin/.travis/test.sh
@@ -75,7 +75,7 @@ docker tag ez_php:latest "ezsystems/php:7.0-${FORMAT_VERSION}"
 export COMPOSE_FILE="doc/docker-compose/base-prod.yml:doc/docker-compose/redis.yml:doc/docker-compose/selenium.yml" SYMFONY_ENV="behat" SYMFONY_DEBUG="0" PHP_IMAGE="ez_php:latest" PHP_IMAGE_DEV="ez_php:latest-dev"
 docker-compose -f doc/docker-compose/install.yml up --abort-on-container-exit
 
-docker-compose up -d
+docker-compose up -d --build --force-recreate
 docker-compose exec --user www-data app sh -c "php /scripts/wait_for_db.php; php app/console cache:warmup; php bin/behat -vv --profile=platformui --tags='@common'"
 docker-compose down -v
 

--- a/php/Dockerfile-5.5
+++ b/php/Dockerfile-5.5
@@ -7,8 +7,7 @@ FROM php:5.5-fpm
 # - (bash|php|composer) Allows to execute composer, php or bash against the image
 
 # Set defaults for variables used by run.sh
-ENV COMPOSER_HOME=/root/.composer \
-    PHPREDIS_VERSION=2.2.8
+ENV COMPOSER_HOME=/root/.composer
 
 # Get packages that we need in container
 RUN apt-get update -q -y \
@@ -59,7 +58,7 @@ RUN set -xe \
     && rm -f /tmp/blackfire-probe.tar.gz \
     \
 # Install redis
-    && yes | pecl install redis-$PHPREDIS_VERSION \
+    && yes | pecl install redis \
     && echo "extension=redis.so" > ${PHP_INI_DIR}/conf.d/redis.ini \
     \
 # Delete source & builds deps so it does not hang around in layers taking up space

--- a/php/Dockerfile-5.6
+++ b/php/Dockerfile-5.6
@@ -7,8 +7,7 @@ FROM php:5.6-fpm
 # - (bash|php|composer) Allows to execute composer, php or bash against the image
 
 # Set defaults for variables used by run.sh
-ENV COMPOSER_HOME=/root/.composer \
-    PHPREDIS_VERSION=2.2.8
+ENV COMPOSER_HOME=/root/.composer
 
 # Get packages that we need in container
 RUN apt-get update -q -y \
@@ -59,7 +58,7 @@ RUN set -xe \
     && rm -f /tmp/blackfire-probe.tar.gz \
     \
 # Install redis
-    && yes | pecl install redis-$PHPREDIS_VERSION \
+    && yes | pecl install redis \
     && echo "extension=redis.so" > ${PHP_INI_DIR}/conf.d/redis.ini \
     \
 # Delete source & builds deps so it does not hang around in layers taking up space

--- a/php/Dockerfile-7.0
+++ b/php/Dockerfile-7.0
@@ -7,8 +7,7 @@ FROM php:7.0-fpm
 # - (bash|php|composer) Allows to execute composer, php or bash against the image
 
 # Set defaults for variables used by run.sh
-ENV COMPOSER_HOME=/root/.composer \
-    PHPREDIS_VERSION=3.0.0
+ENV COMPOSER_HOME=/root/.composer
 
 # Get packages that we need in container
 RUN apt-get update -q -y \
@@ -59,7 +58,7 @@ RUN set -xe \
     && rm -f /tmp/blackfire-probe.tar.gz \
     \
 # Install redis
-    && yes | pecl install redis-$PHPREDIS_VERSION \
+    && yes | pecl install redis \
     && echo "extension=redis.so" > ${PHP_INI_DIR}/conf.d/redis.ini \
     \
 # Delete source & builds deps so it does not hang around in layers taking up space

--- a/php/Dockerfile-7.1
+++ b/php/Dockerfile-7.1
@@ -1,0 +1,97 @@
+FROM php:7.1-fpm
+
+# Container containing php-fpm and php-cli to run and interact with eZ Platform and other Symfony projects
+#
+# It has two modes of operation:
+# - (run.sh cmd) [default] Reconfigure eZ Platform/Publish based on provided env variables and start php-fpm
+# - (bash|php|composer) Allows to execute composer, php or bash against the image
+
+# Set defaults for variables used by run.sh
+ENV COMPOSER_HOME=/root/.composer
+
+# Get packages that we need in container
+RUN apt-get update -q -y \
+    && apt-get install -q -y --force-yes --no-install-recommends \
+        ca-certificates \
+        curl \
+        acl \
+        sudo \
+# Needed for the php extensions we enable below
+        libfreetype6 \
+        libjpeg62-turbo \
+        libxpm4 \
+        libpng12-0 \
+        libicu52 \
+        libxslt1.1 \
+# git & unzip needed for composer, unless we document to use dev image for composer install
+# unzip needed due to https://github.com/composer/composer/issues/4471
+        unzip \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install and configure php plugins
+RUN set -xe \
+    && buildDeps=" \
+        $PHP_EXTRA_BUILD_DEPS \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libxpm-dev \
+        libpng12-dev \
+        libicu-dev \
+        libxslt1-dev \
+    " \
+	&& apt-get update && apt-get install -y --force-yes $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+# Extract php source and install missing extensions
+    && docker-php-source extract \
+    && docker-php-ext-configure mysqli --with-mysqli=mysqlnd \
+    && docker-php-ext-configure pdo_mysql --with-pdo-mysql=mysqlnd \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ --with-xpm-dir=/usr/include/ --enable-gd-native-ttf --enable-gd-jis-conv \
+    && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql \
+    && docker-php-ext-enable opcache \
+    && cp /usr/src/php/php.ini-production ${PHP_INI_DIR}/php.ini \
+    \
+# Install blackfire: https://blackfire.io/docs/integrations/docker
+    && export VERSION=`php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;"` \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/${VERSION} \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp \
+    && mv /tmp/blackfire-*.so `php -r "echo ini_get('extension_dir');"`/blackfire.so \
+    && rm -f /tmp/blackfire-probe.tar.gz \
+    \
+# Install redis
+    && yes | pecl install redis \
+    && echo "extension=redis.so" > ${PHP_INI_DIR}/conf.d/redis.ini \
+    \
+# Delete source & builds deps so it does not hang around in layers taking up space
+    && docker-php-source delete \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps
+
+# Set timezone
+RUN echo "UTC" > /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata
+
+# Set pid file to be able to restart php-fpm
+RUN sed -i "s@^\[global\]@\[global\]\n\npid = /run/php-fpm.pid@" ${PHP_INI_DIR}-fpm.conf
+
+COPY conf.d/blackfire.ini ${PHP_INI_DIR}/conf.d/blackfire.ini
+
+# Create Composer directory (cache and auth files) & Get Composer
+RUN mkdir -p $COMPOSER_HOME \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# As application is put in as volume we do all needed operation on run
+COPY scripts /scripts
+
+# Add some custom config
+COPY conf.d/php.ini ${PHP_INI_DIR}/conf.d/php.ini
+
+RUN chmod 755 /scripts/*.sh
+
+# Needed for docker-machine
+RUN usermod -u 1000 www-data
+
+WORKDIR /var/www
+
+ENTRYPOINT ["/scripts/docker-entrypoint.sh"]
+
+CMD php-fpm
+
+EXPOSE 9000


### PR DESCRIPTION
- Add php 7.1 and make it `latests`
- change all images to use redis ext 3.1.0 which now works with all php versions and fixes several bugs _(hence hardcoding not needed anymore, and hopefully this might stabilize the ext to enable BDD runs with it on ezplatform repo)_