### PR TITLE
Fixed shared library not found error

### DIFF
--- a/bin/.travis/test.sh
+++ b/bin/.travis/test.sh
@@ -28,7 +28,8 @@ if [ "$FORMAT_VERSION" = "" ]; then
 fi
 
 if [ "$EZ_VERSION" = "" ]; then
-    EZ_VERSION="@alpha"
+    # pull in latests stable by default
+    EZ_VERSION=""
 fi
 
 

--- a/bin/.travis/testSymfonyRequirements.php
+++ b/bin/.travis/testSymfonyRequirements.php
@@ -2,7 +2,12 @@
 
 echo ("Running testSymfonyRequirements.php...\n");
 
-require_once dirname(__FILE__) . '/app/SymfonyRequirements.php';
+// Symfony 2 or 3 structure?
+if (file_exists(dirname(__FILE__) . '/app/SymfonyRequirements.php')) {
+    require_once dirname(__FILE__) . '/app/SymfonyRequirements.php';
+} else {
+    require_once dirname(__FILE__) . '/var/SymfonyRequirements.php';
+}
 
 $symfonyRequirements = new SymfonyRequirements();
 

--- a/php/Dockerfile-5.5
+++ b/php/Dockerfile-5.5
@@ -40,9 +40,8 @@ RUN set -xe \
         libpng12-dev \
         libicu-dev \
         libxslt1-dev \
-        libmemcached-dev \
     " \
-	&& apt-get update && apt-get install -y --force-yes $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y --force-yes $buildDeps libmemcached-dev --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 # Extract php source and install missing extensions
     && docker-php-source extract \
     && docker-php-ext-configure mysqli --with-mysqli=mysqlnd \

--- a/php/Dockerfile-5.5
+++ b/php/Dockerfile-5.5
@@ -40,8 +40,13 @@ RUN set -xe \
         libpng12-dev \
         libicu-dev \
         libxslt1-dev \
+        libmemcached-dev \
     " \
-	&& apt-get update && apt-get install -y --force-yes $buildDeps libmemcached-dev --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+    && doNotUninstall=" \
+        libmemcached11 \
+        libmemcachedutil2 \
+    " \
+	&& apt-get update && apt-get install -y --force-yes $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 # Extract php source and install missing extensions
     && docker-php-source extract \
     && docker-php-ext-configure mysqli --with-mysqli=mysqlnd \
@@ -68,6 +73,7 @@ RUN set -xe \
     \
 # Delete source & builds deps so it does not hang around in layers taking up space
     && docker-php-source delete \
+    && apt-mark manual $doNotUninstall \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps
 
 # Set timezone

--- a/php/Dockerfile-5.5
+++ b/php/Dockerfile-5.5
@@ -23,7 +23,7 @@ RUN apt-get update -q -y \
         libpng12-0 \
         libicu52 \
         libxslt1.1 \
-        libmemcached11 \
+        libmemcachedutil2 \
 # git & unzip needed for composer, unless we document to use dev image for composer install
 # unzip needed due to https://github.com/composer/composer/issues/4471
         unzip \
@@ -41,10 +41,6 @@ RUN set -xe \
         libicu-dev \
         libxslt1-dev \
         libmemcached-dev \
-    " \
-    && doNotUninstall=" \
-        libmemcached11 \
-        libmemcachedutil2 \
     " \
 	&& apt-get update && apt-get install -y --force-yes $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 # Extract php source and install missing extensions
@@ -65,15 +61,14 @@ RUN set -xe \
     \
 # Install redis
     && pecl install redis \
-    && echo "extension=redis.so" > ${PHP_INI_DIR}/conf.d/redis.ini \
+    && docker-php-ext-enable redis \
     \
 # Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)
-    && pecl install memcached-2.2.0 \
-    && echo "extension=memcached.so" > ${PHP_INI_DIR}/conf.d/memcached.ini \
+    && echo no | pecl install memcached-2.2.0 \
+    && docker-php-ext-enable memcached \
     \
 # Delete source & builds deps so it does not hang around in layers taking up space
     && docker-php-source delete \
-    && apt-mark manual $doNotUninstall \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps
 
 # Set timezone

--- a/php/Dockerfile-5.6
+++ b/php/Dockerfile-5.6
@@ -40,9 +40,8 @@ RUN set -xe \
         libpng12-dev \
         libicu-dev \
         libxslt1-dev \
-        libmemcached-dev \
     " \
-	&& apt-get update && apt-get install -y --force-yes $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y --force-yes $buildDeps libmemcached-dev --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 # Extract php source and install missing extensions
     && docker-php-source extract \
     && docker-php-ext-configure mysqli --with-mysqli=mysqlnd \

--- a/php/Dockerfile-5.6
+++ b/php/Dockerfile-5.6
@@ -64,7 +64,7 @@ RUN set -xe \
     && docker-php-ext-enable redis \
     \
 # Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)
-    && pecl install memcached-2.2.0 \
+    && echo no | pecl install memcached-2.2.0 \
     && docker-php-ext-enable memcached \
     \
 # Delete source & builds deps so it does not hang around in layers taking up space

--- a/php/Dockerfile-5.6
+++ b/php/Dockerfile-5.6
@@ -40,8 +40,13 @@ RUN set -xe \
         libpng12-dev \
         libicu-dev \
         libxslt1-dev \
+        libmemcached-dev \
     " \
-	&& apt-get update && apt-get install -y --force-yes $buildDeps libmemcached-dev --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+    && doNotUninstall=" \
+        libmemcached11 \
+        libmemcachedutil2 \
+    " \
+	&& apt-get update && apt-get install -y --force-yes $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 # Extract php source and install missing extensions
     && docker-php-source extract \
     && docker-php-ext-configure mysqli --with-mysqli=mysqlnd \
@@ -68,6 +73,7 @@ RUN set -xe \
     \
 # Delete source & builds deps so it does not hang around in layers taking up space
     && docker-php-source delete \
+    && apt-mark manual $doNotUninstall \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps
 
 # Set timezone

--- a/php/Dockerfile-5.6
+++ b/php/Dockerfile-5.6
@@ -23,7 +23,7 @@ RUN apt-get update -q -y \
         libpng12-0 \
         libicu52 \
         libxslt1.1 \
-        libmemcached11 \
+        libmemcachedutil2 \
 # git & unzip needed for composer, unless we document to use dev image for composer install
 # unzip needed due to https://github.com/composer/composer/issues/4471
         unzip \
@@ -41,10 +41,6 @@ RUN set -xe \
         libicu-dev \
         libxslt1-dev \
         libmemcached-dev \
-    " \
-    && doNotUninstall=" \
-        libmemcached11 \
-        libmemcachedutil2 \
     " \
 	&& apt-get update && apt-get install -y --force-yes $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 # Extract php source and install missing extensions
@@ -65,15 +61,14 @@ RUN set -xe \
     \
 # Install redis
     && pecl install redis \
-    && echo "extension=redis.so" > ${PHP_INI_DIR}/conf.d/redis.ini \
+    && docker-php-ext-enable redis \
     \
 # Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)
     && pecl install memcached-2.2.0 \
-    && echo "extension=memcached.so" > ${PHP_INI_DIR}/conf.d/memcached.ini \
+    && docker-php-ext-enable memcached \
     \
 # Delete source & builds deps so it does not hang around in layers taking up space
     && docker-php-source delete \
-    && apt-mark manual $doNotUninstall \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps
 
 # Set timezone


### PR DESCRIPTION
### Description

In Docker images for PHP 5.5 and PHP 5.6 `libmemcached-dev` was removed after installation what caused error `PHP Warning: PHP Startup: Unable to load dynamic library '/usr/local/lib/php/extensions/no-debug-non-zts-xxx/memcached.so`.

The same issue exists in PHP 7.1 Docker image which is currently in Docker Hub. 
After image rebuild, the issue no longer exists. Image available in Docker Hub should be rebuilt and committed again.