### PR TITLE
Added possibility for setting php ini settings via environment variables

### DIFF
--- a/php/scripts/docker-entrypoint.sh
+++ b/php/scripts/docker-entrypoint.sh
@@ -57,5 +57,14 @@ for f in /docker-entrypoint-initdb.d/*; do
     esac
 done
 
+# Scan for environment variables prefixed with PHP_INI_ENV_ and inject those into ${PHP_INI_DIR}/conf.d/zzz_custom_settings.ini
+if [ -f ${PHP_INI_DIR}/conf.d/zzz_custom_settings.ini ]; then rm ${PHP_INI_DIR}/conf.d/zzz_custom_settings.ini; fi
+env | while IFS='=' read -r name value ; do
+  if (echo $name|grep -E "^PHP_INI_ENV">/dev/null); then
+    # remove PHP_INI_ENV_ prefix
+    name=`echo $name | cut -f 4- -d "_"`
+    echo $name=$value >> ${PHP_INI_DIR}/conf.d/zzz_custom_settings.ini
+  fi
+done
 
 exec "$@"


### PR DESCRIPTION
This PR makes it possible to define php.ini settings via environment variables

Environment variables needs to be prefixed with PHP_INI_ENV_, for instance

    docker run -e PHP_INI_ENV_session.save_handler=redis -ti ezsystems/php:vl /bin/bash

This would make it possible to the set php ini settings  like `session.save_handler` and `session.save_path` without having to build your own image or bind mount a extra config file