### PR TITLE
Update xdebug to final for 7.2, use 2.5 for PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - PHP_VERSION="5.6"
     - PHP_VERSION="7.0"
     - PHP_VERSION="7.1"
-    - PHP_VERSION="7.2" XDEBUG_CHANNEL="xdebug-beta"
+    - PHP_VERSION="7.2"
 
 before_script:
   - if [ ! -d ~/.composer/ ] ; then mkdir ~/.composer/; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - FORMAT_VERSION="v1"
   matrix:
     # Run once per Dockerfile-<PHP_VERSION>
-    - PHP_VERSION="5.6"
+    - PHP_VERSION="5.6" XDEBUG_CHANNEL="xdebug-2.5.5"
     - PHP_VERSION="7.0"
     - PHP_VERSION="7.1"
     - PHP_VERSION="7.2"


### PR DESCRIPTION
Xdebug 2.6 is out in final now as required for PHP 7.2, and it requires PHP 7.0 and higher.