### PR TITLE
Added pcntl to PHP

### DIFF
--- a/php/Dockerfile-5.5
+++ b/php/Dockerfile-5.5
@@ -50,6 +50,7 @@ RUN set -xe \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ --with-xpm-dir=/usr/include/ --enable-gd-native-ttf --enable-gd-jis-conv \
     && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql \
     && docker-php-ext-enable opcache \
+    && docker-php-ext-install pcntl \
     && cp /usr/src/php/php.ini-production ${PHP_INI_DIR}/php.ini \
     \
 # Install blackfire: https://blackfire.io/docs/integrations/docker

--- a/php/Dockerfile-5.6
+++ b/php/Dockerfile-5.6
@@ -50,6 +50,7 @@ RUN set -xe \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ --with-xpm-dir=/usr/include/ --enable-gd-native-ttf --enable-gd-jis-conv \
     && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql \
     && docker-php-ext-enable opcache \
+    && docker-php-ext-install pcntl \
     && cp /usr/src/php/php.ini-production ${PHP_INI_DIR}/php.ini \
     \
 # Install blackfire: https://blackfire.io/docs/integrations/docker

--- a/php/Dockerfile-7.0
+++ b/php/Dockerfile-7.0
@@ -50,6 +50,7 @@ RUN set -xe \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ --with-xpm-dir=/usr/include/ --enable-gd-native-ttf --enable-gd-jis-conv \
     && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql \
     && docker-php-ext-enable opcache \
+    && docker-php-ext-install pcntl \
     && cp /usr/src/php/php.ini-production ${PHP_INI_DIR}/php.ini \
     \
 # Install blackfire: https://blackfire.io/docs/integrations/docker

--- a/php/Dockerfile-7.1
+++ b/php/Dockerfile-7.1
@@ -50,6 +50,7 @@ RUN set -xe \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ --with-xpm-dir=/usr/include/ --enable-gd-native-ttf --enable-gd-jis-conv \
     && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql \
     && docker-php-ext-enable opcache \
+    && docker-php-ext-install pcntl \
     && cp /usr/src/php/php.ini-production ${PHP_INI_DIR}/php.ini \
     \
 # Install blackfire: https://blackfire.io/docs/integrations/docker

--- a/php/Dockerfile-7.2
+++ b/php/Dockerfile-7.2
@@ -50,6 +50,7 @@ RUN set -xe \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ --with-xpm-dir=/usr/include/ --enable-gd-native-ttf --enable-gd-jis-conv \
     && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql \
     && docker-php-ext-enable opcache \
+    && docker-php-ext-install pcntl \
     && cp /usr/src/php/php.ini-production ${PHP_INI_DIR}/php.ini \
     \
 # Install blackfire: https://blackfire.io/docs/integrations/docker


### PR DESCRIPTION
Added pcntl in order to be able to call [pcntl_fork()](http://php.net/manual/en/function.pcntl-fork.php)

Needed by [ezplatform-xmltext-fieldtype
](https://github.com/ezsystems/ezplatform-xmltext-fieldtype/pull/49/files)