### PR TITLE
Add support for igbinary to reduce serialization size on Redis & Memcached

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ env:
   global:
     - REMOTE_IMAGE="ezsystems/php"
     - LATEST="7.2"
-    - FORMAT_VERSION="v1"
+    - FORMAT_VERSION="v2"
   matrix:
     # Run once per Dockerfile-<PHP_VERSION>
-    - PHP_VERSION="5.6" XDEBUG_CHANNEL="xdebug-2.5.5"
+    - PHP_VERSION="5.6" XDEBUG_CHANNEL="xdebug-2.5.5" EZ_VERSION="v1.13.4-beta1 || v1.13.4"
     - PHP_VERSION="7.0"
     - PHP_VERSION="7.1"
     - PHP_VERSION="7.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   global:
     - REMOTE_IMAGE="ezsystems/php"
     - LATEST="7.2"
-    - FORMAT_VERSION="v2"
+    - FORMAT_VERSION="v1"
   matrix:
     # Run once per Dockerfile-<PHP_VERSION>
     - PHP_VERSION="5.6" XDEBUG_CHANNEL="xdebug-2.5.5" EZ_VERSION="v1.13.4-beta1 || ^1.13.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - FORMAT_VERSION="v2"
   matrix:
     # Run once per Dockerfile-<PHP_VERSION>
-    - PHP_VERSION="5.6" XDEBUG_CHANNEL="xdebug-2.5.5" EZ_VERSION="v1.13.4-beta1 || v1.13.4"
+    - PHP_VERSION="5.6" XDEBUG_CHANNEL="xdebug-2.5.5" EZ_VERSION="v1.13.4-beta1 || ^1.13.4"
     - PHP_VERSION="7.0"
     - PHP_VERSION="7.1"
     - PHP_VERSION="7.2"

--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ For setting up a full setup with database and so on, see [ezplatform:doc/docker]
 - env variable to set session handler, ...
 - Apache + mod_php variant
 - Alpine Linux; *To drop image size, assuming all other official images move to Alpine, incl when blackfire supports it.*
-  - _Note: As of v2 format the difference is not that large anymore as PHP images now build on debian:stretch-slim._
 
 ## Copyright & license
 Copyright [eZ Systems AS](http://ez.no/), for copyright and license details see provided LICENSE file.

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ _NOTE: The images here, just like the official once they extend, are meant to fo
 PHP image that aims to technically support running:
 - eZ Platform
 - eZ Platform EE
-- eZ Publish 5.4 *(latests 5.4.x version)*
+- eZ Publish 5.4 *(5.4.11 or higher)*
 - Symfony *(As in any symfony-standard like app that have same or less requirements then eZ Platform)*
 
 ## Images
 
 This repository contains several images for different versions of PHP\*:
-- [7.2](php/Dockerfile-7.2) *(new image based on debian:stretch-slim)*
-- [7.1](php/Dockerfile-7.1) *(Recommended version for testing newest versions of eZ Platform)*
+- [7.2](php/Dockerfile-7.2) *(Recommended version for testing newest versions of eZ Platform)*
+- [7.1](php/Dockerfile-7.1)
 - [7.0](php/Dockerfile-7.0)
 - [5.6](php/Dockerfile-5.6) *(Security fixes only, time to start to move to PHP7)*
 - ~~[5.5](php/Dockerfile-5.5) *(End of Life, so only meant for compatibility testing for older maintenance releases)*~~
@@ -42,8 +42,14 @@ For each php version there is an additional `-dev` flavour with additional tools
 
 To be able to improve the image in the future, we have added a format version number that we will increase on future changes *(for instance move to Alpine Linux)*.
 
-It is recommended to specificy a tag with this format version number in your Docker / docker-compose use to avoid breaks in your application.
+It is recommended to specify a tag with this format version number in your Docker / docker-compose use to avoid breaks in your application.
 
+
+#### Changelog
+- v2
+  - As done by upstream PHP image, switched to Debian 9 (debian:stretch-slim) for all supported images (PHP 5.6 - 7.2)
+  - Removed msgpack ext, replaced with igbinary _(+ configure for redis, memcached & session serialization)_
+- v1: Initial stable version
 
 ## Usage
 
@@ -52,22 +58,22 @@ allows you to use the same image across all whole DevOps life cycle *(dev, build
 
 Before you start, you can test the image to see if you get which php version it is running:
 ```bash
-docker run --rm ezsystems/php:7.1-v1 php -v
+docker run --rm ezsystems/php:7.2 php -v
 ```
 
 This should result in *something* like:
 ```
-PHP 7.1.0 (cli) (built: Dec 14 2016 15:01:30) ( NTS )
-Copyright (c) 1997-2016 The PHP Group
-Zend Engine v3.1.0, Copyright (c) 1998-2016 Zend Technologies
-    with Zend OPcache v7.1.0, Copyright (c) 1999-2016, by Zend Technologies
-    with blackfire v1.14.1~linux-x64-non_zts71, https://blackfire.io, by Blackfireio Inc.
+PHP 7.2.8 (cli) (built: Jul 21 2018 07:56:11) ( NTS )
+Copyright (c) 1997-2018 The PHP Group
+Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
+    with Zend OPcache v7.2.8, Copyright (c) 1999-2018, by Zend Technologies
+    with blackfire v1.22.0~linux-x64-non_zts72, https://blackfire.io, by Blackfire
 ```
 
 ### Production use
 
 In your application folder, you'll need to add a `Dockerfile` where you customize it, including adding your application.
-For example see for instance [Dockerfile in ezsystems/ezplatform](https://github.com/ezsystems/ezplatform/blob/master/Dockerfile).
+For example see for instance [Dockerfile in ezsystems/ezplatform](https://github.com/ezsystems/ezplatform/blob/master/doc/docker/Dockerfile-app).
 
 
 Then for building it you can for instance execute:
@@ -77,25 +83,25 @@ docker build -t mycompany/myapp_volume:latest .
 
 And by now you can execute some *(see below to attach database, ..)* commands to test it:
 ```bash
-docker run --rm mycompany/myapp_volume app/console list
+docker run --rm mycompany/myapp_volume bin/console list
 ```
 
 ### Development use
 
 *Warning: As of December 2016, avoid using Docker for Mac/Windows beta for this setup, as it's load times are typically 60-90 seconds because of IO issues way worse then what Virtualbox ever had when doing shared folder. Which is essentially what is being used here when not on Linux, and when using what Docker calls host mounted volumes.*
 
-To get started, lets set permissions for dev use _(Symfony 2.x structure reflected in example)_, and make sure to install composer packages:
+To get started, lets set permissions for dev use _(Symfony 3.x structure reflected in example)_, and make sure to install composer packages:
 ```bash
 sudo mkdir -p web/var
-sudo find {app/{cache,logs},web/var} -type d | xargs sudo chmod -R 777
-sudo find {app/{cache,logs},web/var} -type f | xargs sudo chmod -R 666
-docker run --rm -u www-data -v `pwd`:/var/www -e SYMFONY_ENV=dev ezsystems/php:7.0-v0 composer install --no-progress --no-interaction --prefer-dist
+sudo find web/var var -type d | xargs sudo chmod -R 777
+sudo find web/var var -type f | xargs sudo chmod -R 666
+docker run --rm -u www-data -v `pwd`:/var/www -e SYMFONY_ENV=dev ezsystems/php:7.2 composer install --no-progress --no-interaction --prefer-dist
 ```
 
 
 Now you can run some *(see below to attach database, ..)* commands to test it:
 ```bash
-docker run --rm -u www-data -v `pwd`:/var/www -e SYMFONY_ENV=dev ezsystems/php:7.0-v0 app/console list
+docker run --rm -u www-data -v `pwd`:/var/www -e SYMFONY_ENV=dev ezsystems/php:7.2 bin/console list
 ```
 
 
@@ -104,13 +110,14 @@ docker run --rm -u www-data -v `pwd`:/var/www -e SYMFONY_ENV=dev ezsystems/php:7
 For setting up a full setup with database and so on, see [ezplatform:doc/docker](https://github.com/ezsystems/ezplatform/tree/master/doc/docker) for further examples and instructions.
 
 
-## Roadmap for this PHP image
+## Possible roadmap for this PHP image
 
 - PHP plugins:
  - pdo_pgsql + pdo_sqlite
 - env variable to set session handler, ...
 - Apache + mod_php variant
 - Alpine Linux; *To drop image size, assuming all other official images move to Alpine, incl when blackfire supports it.*
+  - _Note: As of v2 format the difference is not that large anymore as PHP images now build on debian:stretch-slim._
 
 ## Copyright & license
 Copyright [eZ Systems AS](http://ez.no/), for copyright and license details see provided LICENSE file.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ PHP image that aims to technically support running:
 ## Images
 
 This repository contains several images for different versions of PHP\*:
-- [7.2](php/Dockerfile-7.2) *(Recommended version for testing newest versions of eZ Platform)*
-- [7.1](php/Dockerfile-7.1)
+- [7.2](php/Dockerfile-7.2) *(NOTE: Based on debian:stretch-slim and not jessie like the others atm in v1 format)*
+- [7.1](php/Dockerfile-7.1) *(Recommended version for testing newest versions of eZ Platform)*
 - [7.0](php/Dockerfile-7.0)
 - [5.6](php/Dockerfile-5.6) *(Security fixes only, time to start to move to PHP7)*
 - ~~[5.5](php/Dockerfile-5.5) *(End of Life, so only meant for compatibility testing for older maintenance releases)*~~
@@ -44,12 +44,6 @@ To be able to improve the image in the future, we have added a format version nu
 
 It is recommended to specify a tag with this format version number in your Docker / docker-compose use to avoid breaks in your application.
 
-
-#### Changelog
-- v2
-  - As done by upstream PHP image, switched to Debian 9 (debian:stretch-slim) for all supported images (PHP 5.6 - 7.2)
-  - Removed msgpack ext, replaced with igbinary _(+ configure for redis, memcached & session serialization)_
-- v1: Initial stable version
 
 ## Usage
 

--- a/bin/.travis/test.sh
+++ b/bin/.travis/test.sh
@@ -28,7 +28,7 @@ if [ "$FORMAT_VERSION" = "" ]; then
 fi
 
 if [ "$EZ_VERSION" = "" ]; then
-    # pull in latest stable by default (TODO: v2 does not yet work with redis so we test v1)
+    # pull in latest stable by default (TODO: change to be able to test against v2)
     EZ_VERSION="^1.13.0"
 fi
 
@@ -85,7 +85,7 @@ export COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/redis.yml:doc/docker/sel
 docker-compose -f doc/docker/install.yml up --abort-on-container-exit
 
 docker-compose up -d --build --force-recreate
-docker-compose exec --user www-data app sh -c "php /scripts/wait_for_db.php; php app/console cache:warmup; php bin/behat -vv --profile=rest --suite=fullJson --tags=~@broken"
+docker-compose exec --user www-data app sh -c "php /scripts/wait_for_db.php; php app/console cache:warmup; php bin/behat -vv --profile=platformui --tags='@common'"
 docker-compose down -v
 
 # Remove custom tag

--- a/bin/.travis/test.sh
+++ b/bin/.travis/test.sh
@@ -77,9 +77,14 @@ docker run -ti --rm ez_php:latest-dev bash -c "php -v; php -m"
 printf "\Integration: Behat testing on ez_php:latest and ez_php:latest-dev with eZ Platform\n"
 cd volumes/ezplatform
 
-# Tag image as eZ Platform extends on of these exact images and we don't want it to pull in remote
-docker tag ez_php:latest "ezsystems/php:7.2-${FORMAT_VERSION}"
+# Tag image alias for what (exactly) eZ Platform is currently using in order to be able to test across branches
+## As we don't want it to pull in remote, but rather use what we just built here
+## NOTE: On larger changes to this images, we would need to pull in custom branches with adaptions on Platform side as well as below
+## TODO: The tag aliases here will not be needed once eZ Platform uses PHP_IMAGE variable within Dockerfile's from section
+# For 1.13 and 2.x ATM
 docker tag ez_php:latest "ezsystems/php:7.1-v1"
+# For 1.7.x ATM
+docker tag ez_php:latest "ezsystems/php:7.0-v1"
 
 export COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/redis.yml:doc/docker/selenium.yml" SYMFONY_ENV="behat" SYMFONY_DEBUG="0" PHP_IMAGE="ez_php:latest" PHP_IMAGE_DEV="ez_php:latest-dev"
 docker-compose -f doc/docker/install.yml up --abort-on-container-exit
@@ -88,6 +93,6 @@ docker-compose up -d --build --force-recreate
 docker-compose exec --user www-data app sh -c "php /scripts/wait_for_db.php; php app/console cache:warmup; php bin/behat -vv --profile=platformui --tags='@common'"
 docker-compose down -v
 
-# Remove custom tag
-docker rmi "ezsystems/php:7.2-${FORMAT_VERSION}"
+# Remove custom tag aliases used for Platform testing
 docker rmi "ezsystems/php:7.1-v1"
+docker rmi "ezsystems/php:7.0-v1"

--- a/bin/.travis/test.sh
+++ b/bin/.travis/test.sh
@@ -28,8 +28,8 @@ if [ "$FORMAT_VERSION" = "" ]; then
 fi
 
 if [ "$EZ_VERSION" = "" ]; then
-    # pull in latests stable by default
-    EZ_VERSION="^1.12.0"
+    # Let composer pick suitable eZ version by default depending on PHP version
+    EZ_VERSION=""
 fi
 
 
@@ -78,16 +78,16 @@ printf "\Integration: Behat testing on ez_php:latest and ez_php:latest-dev with 
 cd volumes/ezplatform
 
 # Tag image as eZ Platform extends on of these exact images and we don't want it to pull in remote
-docker tag ez_php:latest "ezsystems/php:7.1-${FORMAT_VERSION}"
-docker tag ez_php:latest "ezsystems/php:7.0-${FORMAT_VERSION}"
+docker tag ez_php:latest "ezsystems/php:7.2-${FORMAT_VERSION}"
+docker tag ez_php:latest "ezsystems/php:7.1-v1"
 
 export COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/redis.yml:doc/docker/selenium.yml" SYMFONY_ENV="behat" SYMFONY_DEBUG="0" PHP_IMAGE="ez_php:latest" PHP_IMAGE_DEV="ez_php:latest-dev"
 docker-compose -f doc/docker/install.yml up --abort-on-container-exit
 
 docker-compose up -d --build --force-recreate
-docker-compose exec --user www-data app sh -c "php /scripts/wait_for_db.php; php app/console cache:warmup; php bin/behat -vv --profile=platformui --tags='@common'"
+docker-compose exec --user www-data app sh -c "php /scripts/wait_for_db.php; php app/console cache:warmup; php bin/behat -vv --profile=rest --suite=fullJson --tags=~@broken"
 docker-compose down -v
 
 # Remove custom tag
-docker rmi "ezsystems/php:7.1-${FORMAT_VERSION}"
-docker rmi "ezsystems/php:7.0-${FORMAT_VERSION}"
+docker rmi "ezsystems/php:7.2-${FORMAT_VERSION}"
+docker rmi "ezsystems/php:7.1-v1"

--- a/bin/.travis/test.sh
+++ b/bin/.travis/test.sh
@@ -28,8 +28,8 @@ if [ "$FORMAT_VERSION" = "" ]; then
 fi
 
 if [ "$EZ_VERSION" = "" ]; then
-    # Let composer pick suitable eZ version by default depending on PHP version
-    EZ_VERSION=""
+    # pull in latest stable by default (TODO: v2 does not yet work with redis so we test v1)
+    EZ_VERSION="^1.13.0"
 fi
 
 

--- a/bin/.travis/update_docker.sh
+++ b/bin/.travis/update_docker.sh
@@ -12,7 +12,7 @@ docker -v
 
 
 docker-compose -v
-DOCKER_COMPOSE_VERSION="1.17.1"
+DOCKER_COMPOSE_VERSION="1.22.0"
 echo "\nUpdating Docker Compose to ${DOCKER_COMPOSE_VERSION}"
 sudo rm -f /usr/local/bin/docker-compose
 curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose

--- a/php/Dockerfile-5.6
+++ b/php/Dockerfile-5.6
@@ -1,4 +1,4 @@
-FROM php:5.6-fpm
+FROM php:5.6-fpm-jessie
 
 # Container containing php-fpm and php-cli to run and interact with eZ Platform and other Symfony projects
 #
@@ -11,7 +11,7 @@ ENV COMPOSER_HOME=/root/.composer
 
 # Get packages that we need in container
 RUN apt-get update -q -y \
-    && apt-get install -q -y --no-install-recommends \
+    && apt-get install -q -y --force-yes --no-install-recommends \
         ca-certificates \
         curl \
         acl \
@@ -20,8 +20,8 @@ RUN apt-get update -q -y \
         libfreetype6 \
         libjpeg62-turbo \
         libxpm4 \
-        libpng16-16 \
-        libicu57 \
+        libpng12-0 \
+        libicu52 \
         libxslt1.1 \
         libmemcachedutil2 \
 # git & unzip needed for composer, unless we document to use dev image for composer install
@@ -37,12 +37,12 @@ RUN set -xe \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libxpm-dev \
-        libpng-dev \
+        libpng12-dev \
         libicu-dev \
         libxslt1-dev \
         libmemcached-dev \
     " \
-	&& apt-get update -q -y && apt-get install -q -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y --force-yes $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 # Extract php source and install missing extensions
     && docker-php-source extract \
     && docker-php-ext-configure mysqli --with-mysqli=mysqlnd \

--- a/php/Dockerfile-5.6
+++ b/php/Dockerfile-5.6
@@ -74,11 +74,18 @@ RUN set -xe \
     && cd - \
     \
 # Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)
-    && for i in $(seq 1 3); do echo no | pecl install -o memcached-2.2.0 && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && for i in $(seq 1 3); do echo no | pecl install -o --nobuild memcached-2.2.0 && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && cd "$(pecl config-get temp_dir)/memcached" \
+    && phpize \
+    && ./configure --enable-memcached-igbinary \
+    && make \
+    && make install \
     && docker-php-ext-enable memcached \
+    && cd - \
     \
 # Delete source & builds deps so it does not hang around in layers taking up space
     && pecl clear-cache \
+    && rm -Rf "$(pecl config-get temp_dir)/*" \
     && docker-php-source delete \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps
 

--- a/php/Dockerfile-5.6
+++ b/php/Dockerfile-5.6
@@ -1,4 +1,4 @@
-FROM php:5.6-fpm
+FROM php:5.6-fpm-jessie
 
 # Container containing php-fpm and php-cli to run and interact with eZ Platform and other Symfony projects
 #
@@ -20,8 +20,8 @@ RUN apt-get update -q -y \
         libfreetype6 \
         libjpeg62-turbo \
         libxpm4 \
-        libpng16-16 \
-        libicu57 \
+        libpng12-0 \
+        libicu52 \
         libxslt1.1 \
         libmemcachedutil2 \
 # git & unzip needed for composer, unless we document to use dev image for composer install
@@ -37,7 +37,7 @@ RUN set -xe \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libxpm-dev \
-        libpng-dev \
+        libpng12-dev \
         libicu-dev \
         libxslt1-dev \
         libmemcached-dev \

--- a/php/Dockerfile-5.6
+++ b/php/Dockerfile-5.6
@@ -47,7 +47,7 @@ RUN set -xe \
     && docker-php-source extract \
     && docker-php-ext-configure mysqli --with-mysqli=mysqlnd \
     && docker-php-ext-configure pdo_mysql --with-pdo-mysql=mysqlnd \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ --with-xpm-dir=/usr/include/ --enable-gd-jis-conv \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ --with-xpm-dir=/usr/include/ --enable-gd-native-ttf --enable-gd-jis-conv \
     && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql \
     && docker-php-ext-enable opcache \
     && cp /usr/src/php/php.ini-production ${PHP_INI_DIR}/php.ini \
@@ -59,26 +59,15 @@ RUN set -xe \
     && mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -f /tmp/blackfire-probe.tar.gz \
     \
-# Install igbinary (for more efficient serialization in redis/memcached)
-    && for i in $(seq 1 3); do pecl install -o igbinary && s=0 && break || s=$? && sleep 1; done; (exit $s) \
-    && docker-php-ext-enable igbinary \
-    \
-# Install redis (manualy build in order to be able to enable igbinary)
-    && for i in $(seq 1 3); do pecl install -o --nobuild redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
-    && cd "$(pecl config-get temp_dir)/redis" \
-    && phpize \
-    && ./configure --enable-redis-igbinary \
-    && make \
-    && make install \
+# Install redis
+    && for i in $(seq 1 3); do pecl install -o redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable redis \
-    && cd - \
     \
 # Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)
     && for i in $(seq 1 3); do echo no | pecl install -o memcached-2.2.0 && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable memcached \
     \
 # Delete source & builds deps so it does not hang around in layers taking up space
-    && pecl clear-cache \
     && docker-php-source delete \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps
 

--- a/php/Dockerfile-5.6
+++ b/php/Dockerfile-5.6
@@ -73,7 +73,7 @@ RUN set -xe \
     && docker-php-ext-enable redis \
     && cd - \
     \
-# Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)
+# Install memcached (manualy build in order to be able to enable igbinary)
     && for i in $(seq 1 3); do echo no | pecl install -o --nobuild memcached-2.2.0 && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && cd "$(pecl config-get temp_dir)/memcached" \
     && phpize \

--- a/php/Dockerfile-5.6
+++ b/php/Dockerfile-5.6
@@ -11,7 +11,7 @@ ENV COMPOSER_HOME=/root/.composer
 
 # Get packages that we need in container
 RUN apt-get update -q -y \
-    && apt-get install -q -y --force-yes --no-install-recommends \
+    && apt-get install -q -y --no-install-recommends \
         ca-certificates \
         curl \
         acl \
@@ -20,8 +20,8 @@ RUN apt-get update -q -y \
         libfreetype6 \
         libjpeg62-turbo \
         libxpm4 \
-        libpng12-0 \
-        libicu52 \
+        libpng16-16 \
+        libicu57 \
         libxslt1.1 \
         libmemcachedutil2 \
 # git & unzip needed for composer, unless we document to use dev image for composer install
@@ -37,12 +37,12 @@ RUN set -xe \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libxpm-dev \
-        libpng12-dev \
+        libpng-dev \
         libicu-dev \
         libxslt1-dev \
         libmemcached-dev \
     " \
-	&& apt-get update && apt-get install -y --force-yes $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update -q -y && apt-get install -q -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
 # Extract php source and install missing extensions
     && docker-php-source extract \
     && docker-php-ext-configure mysqli --with-mysqli=mysqlnd \

--- a/php/Dockerfile-5.6
+++ b/php/Dockerfile-5.6
@@ -59,6 +59,10 @@ RUN set -xe \
     && mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -f /tmp/blackfire-probe.tar.gz \
     \
+# Install igbinary (for more efficient serialization in redis/memcached)
+    && for i in $(seq 1 3); do pecl install -o igbinary && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && docker-php-ext-enable igbinary \
+    \
 # Install redis
     && for i in $(seq 1 3); do pecl install -o redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable redis \

--- a/php/Dockerfile-5.6
+++ b/php/Dockerfile-5.6
@@ -47,7 +47,7 @@ RUN set -xe \
     && docker-php-source extract \
     && docker-php-ext-configure mysqli --with-mysqli=mysqlnd \
     && docker-php-ext-configure pdo_mysql --with-pdo-mysql=mysqlnd \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ --with-xpm-dir=/usr/include/ --enable-gd-native-ttf --enable-gd-jis-conv \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ --with-xpm-dir=/usr/include/ --enable-gd-jis-conv \
     && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql \
     && docker-php-ext-enable opcache \
     && cp /usr/src/php/php.ini-production ${PHP_INI_DIR}/php.ini \
@@ -63,15 +63,22 @@ RUN set -xe \
     && for i in $(seq 1 3); do pecl install -o igbinary && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable igbinary \
     \
-# Install redis
-    && for i in $(seq 1 3); do pecl install -o --enable-redis-igbinary redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+# Install redis (manualy build in order to be able to enable igbinary)
+    && for i in $(seq 1 3); do pecl install -o --nobuild redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && cd "$(pecl config-get temp_dir)/redis" \
+    && phpize \
+    && ./configure --enable-redis-igbinary \
+    && make \
+    && make install \
     && docker-php-ext-enable redis \
+    && cd - \
     \
 # Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)
     && for i in $(seq 1 3); do echo no | pecl install -o memcached-2.2.0 && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable memcached \
     \
 # Delete source & builds deps so it does not hang around in layers taking up space
+    && pecl clear-cache \
     && docker-php-source delete \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps
 

--- a/php/Dockerfile-5.6
+++ b/php/Dockerfile-5.6
@@ -1,4 +1,4 @@
-FROM php:5.6-fpm-jessie
+FROM php:5.6-fpm
 
 # Container containing php-fpm and php-cli to run and interact with eZ Platform and other Symfony projects
 #
@@ -11,7 +11,7 @@ ENV COMPOSER_HOME=/root/.composer
 
 # Get packages that we need in container
 RUN apt-get update -q -y \
-    && apt-get install -q -y --force-yes --no-install-recommends \
+    && apt-get install -q -y --no-install-recommends \
         ca-certificates \
         curl \
         acl \
@@ -20,8 +20,8 @@ RUN apt-get update -q -y \
         libfreetype6 \
         libjpeg62-turbo \
         libxpm4 \
-        libpng12-0 \
-        libicu52 \
+        libpng16-16 \
+        libicu57 \
         libxslt1.1 \
         libmemcachedutil2 \
 # git & unzip needed for composer, unless we document to use dev image for composer install
@@ -37,12 +37,12 @@ RUN set -xe \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libxpm-dev \
-        libpng12-dev \
+        libpng-dev \
         libicu-dev \
         libxslt1-dev \
         libmemcached-dev \
     " \
-	&& apt-get update && apt-get install -y --force-yes $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update -q -y && apt-get install -q -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
 # Extract php source and install missing extensions
     && docker-php-source extract \
     && docker-php-ext-configure mysqli --with-mysqli=mysqlnd \

--- a/php/Dockerfile-5.6
+++ b/php/Dockerfile-5.6
@@ -64,7 +64,7 @@ RUN set -xe \
     && docker-php-ext-enable igbinary \
     \
 # Install redis
-    && for i in $(seq 1 3); do pecl install -o redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && for i in $(seq 1 3); do pecl install -o --enable-redis-igbinary redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable redis \
     \
 # Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)

--- a/php/Dockerfile-5.6
+++ b/php/Dockerfile-5.6
@@ -47,7 +47,7 @@ RUN set -xe \
     && docker-php-source extract \
     && docker-php-ext-configure mysqli --with-mysqli=mysqlnd \
     && docker-php-ext-configure pdo_mysql --with-pdo-mysql=mysqlnd \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ --with-xpm-dir=/usr/include/ --enable-gd-native-ttf --enable-gd-jis-conv \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ --with-xpm-dir=/usr/include/ --enable-gd-jis-conv \
     && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql \
     && docker-php-ext-enable opcache \
     && cp /usr/src/php/php.ini-production ${PHP_INI_DIR}/php.ini \
@@ -59,15 +59,26 @@ RUN set -xe \
     && mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -f /tmp/blackfire-probe.tar.gz \
     \
-# Install redis
-    && for i in $(seq 1 3); do pecl install -o redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+# Install igbinary (for more efficient serialization in redis/memcached)
+    && for i in $(seq 1 3); do pecl install -o igbinary && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && docker-php-ext-enable igbinary \
+    \
+# Install redis (manualy build in order to be able to enable igbinary)
+    && for i in $(seq 1 3); do pecl install -o --nobuild redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && cd "$(pecl config-get temp_dir)/redis" \
+    && phpize \
+    && ./configure --enable-redis-igbinary \
+    && make \
+    && make install \
     && docker-php-ext-enable redis \
+    && cd - \
     \
 # Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)
     && for i in $(seq 1 3); do echo no | pecl install -o memcached-2.2.0 && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable memcached \
     \
 # Delete source & builds deps so it does not hang around in layers taking up space
+    && pecl clear-cache \
     && docker-php-source delete \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps
 

--- a/php/Dockerfile-7.0
+++ b/php/Dockerfile-7.0
@@ -59,11 +59,6 @@ RUN set -xe \
     && mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -f /tmp/blackfire-probe.tar.gz \
     \
-# Install msgpack (for more efficient serialization in memcached)
-# @DEPRECATED @TODO Consider to be removed in v2 format version, atm igbinary (v2) is more widely supported.
-    && for i in $(seq 1 3); do pecl install -o msgpack && s=0 && break || s=$? && sleep 1; done; (exit $s) \
-    && docker-php-ext-enable msgpack \
-    \
 # Install igbinary (for more efficient serialization in redis/memcached)
     && for i in $(seq 1 3); do pecl install -o igbinary && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable igbinary \

--- a/php/Dockerfile-7.0
+++ b/php/Dockerfile-7.0
@@ -79,11 +79,18 @@ RUN set -xe \
     && cd - \
     \
 # Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)
-    && for i in $(seq 1 3); do echo no | pecl install -o memcached && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && for i in $(seq 1 3); do echo no | pecl install -o --nobuild memcached && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && cd "$(pecl config-get temp_dir)/memcached" \
+    && phpize \
+    && ./configure --enable-memcached-igbinary \
+    && make \
+    && make install \
     && docker-php-ext-enable memcached \
+    && cd - \
     \
 # Delete source & builds deps so it does not hang around in layers taking up space
     && pecl clear-cache \
+    && rm -Rf "$(pecl config-get temp_dir)/*" \
     && docker-php-source delete \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps
 

--- a/php/Dockerfile-7.0
+++ b/php/Dockerfile-7.0
@@ -11,7 +11,7 @@ ENV COMPOSER_HOME=/root/.composer
 
 # Get packages that we need in container
 RUN apt-get update -q -y \
-    && apt-get install -q -y --force-yes --no-install-recommends \
+    && apt-get install -q -y --no-install-recommends \
         ca-certificates \
         curl \
         acl \
@@ -20,8 +20,8 @@ RUN apt-get update -q -y \
         libfreetype6 \
         libjpeg62-turbo \
         libxpm4 \
-        libpng12-0 \
-        libicu52 \
+        libpng16-16 \
+        libicu57 \
         libxslt1.1 \
         libmemcachedutil2 \
 # git & unzip needed for composer, unless we document to use dev image for composer install
@@ -37,12 +37,12 @@ RUN set -xe \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libxpm-dev \
-        libpng12-dev \
+        libpng-dev \
         libicu-dev \
         libxslt1-dev \
         libmemcached-dev \
     " \
-	&& apt-get update && apt-get install -y --force-yes $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update -q -y && apt-get install -q -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
 # Extract php source and install missing extensions
     && docker-php-source extract \
     && docker-php-ext-configure mysqli --with-mysqli=mysqlnd \

--- a/php/Dockerfile-7.0
+++ b/php/Dockerfile-7.0
@@ -47,7 +47,7 @@ RUN set -xe \
     && docker-php-source extract \
     && docker-php-ext-configure mysqli --with-mysqli=mysqlnd \
     && docker-php-ext-configure pdo_mysql --with-pdo-mysql=mysqlnd \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ --with-xpm-dir=/usr/include/ --enable-gd-native-ttf --enable-gd-jis-conv \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ --with-xpm-dir=/usr/include/ --enable-gd-jis-conv \
     && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql \
     && docker-php-ext-enable opcache \
     && cp /usr/src/php/php.ini-production ${PHP_INI_DIR}/php.ini \
@@ -68,15 +68,22 @@ RUN set -xe \
     && for i in $(seq 1 3); do pecl install -o igbinary && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable igbinary \
     \
-# Install redis
-    && for i in $(seq 1 3); do pecl install -o --enable-redis-igbinary redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+# Install redis (manualy build in order to be able to enable igbinary)
+    && for i in $(seq 1 3); do pecl install -o --nobuild redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && cd "$(pecl config-get temp_dir)/redis" \
+    && phpize \
+    && ./configure --enable-redis-igbinary \
+    && make \
+    && make install \
     && docker-php-ext-enable redis \
+    && cd - \
     \
 # Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)
     && for i in $(seq 1 3); do echo no | pecl install -o memcached && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable memcached \
     \
 # Delete source & builds deps so it does not hang around in layers taking up space
+    && pecl clear-cache \
     && docker-php-source delete \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps
 

--- a/php/Dockerfile-7.0
+++ b/php/Dockerfile-7.0
@@ -69,7 +69,7 @@ RUN set -xe \
     && docker-php-ext-enable igbinary \
     \
 # Install redis
-    && for i in $(seq 1 3); do pecl install -o redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && for i in $(seq 1 3); do pecl install -o --enable-redis-igbinary redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable redis \
     \
 # Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)

--- a/php/Dockerfile-7.0
+++ b/php/Dockerfile-7.0
@@ -73,7 +73,7 @@ RUN set -xe \
     && docker-php-ext-enable redis \
     && cd - \
     \
-# Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)
+# Install memcached (manualy build in order to be able to enable igbinary)
     && for i in $(seq 1 3); do echo no | pecl install -o --nobuild memcached && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && cd "$(pecl config-get temp_dir)/memcached" \
     && phpize \

--- a/php/Dockerfile-7.0
+++ b/php/Dockerfile-7.0
@@ -59,9 +59,14 @@ RUN set -xe \
     && mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -f /tmp/blackfire-probe.tar.gz \
     \
-# Install msgpack (for more efficient serialization in redis/memcached)
+# Install msgpack (for more efficient serialization in memcached)
+# @DEPRECATED @TODO Consider to be removed in v2 format version, atm igbinary (v2) is more widely supported.
     && for i in $(seq 1 3); do pecl install -o msgpack && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable msgpack \
+    \
+# Install igbinary (for more efficient serialization in redis/memcached)
+    && for i in $(seq 1 3); do pecl install -o igbinary && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && docker-php-ext-enable igbinary \
     \
 # Install redis
     && for i in $(seq 1 3); do pecl install -o redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \

--- a/php/Dockerfile-7.0
+++ b/php/Dockerfile-7.0
@@ -1,4 +1,4 @@
-FROM php:7.0-fpm
+FROM php:7.0-fpm-jessie
 
 # Container containing php-fpm and php-cli to run and interact with eZ Platform and other Symfony projects
 #
@@ -20,8 +20,8 @@ RUN apt-get update -q -y \
         libfreetype6 \
         libjpeg62-turbo \
         libxpm4 \
-        libpng16-16 \
-        libicu57 \
+        libpng12-0 \
+        libicu52 \
         libxslt1.1 \
         libmemcachedutil2 \
 # git & unzip needed for composer, unless we document to use dev image for composer install
@@ -37,7 +37,7 @@ RUN set -xe \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libxpm-dev \
-        libpng-dev \
+        libpng12-dev \
         libicu-dev \
         libxslt1-dev \
         libmemcached-dev \

--- a/php/Dockerfile-7.1
+++ b/php/Dockerfile-7.1
@@ -59,11 +59,6 @@ RUN set -xe \
     && mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -f /tmp/blackfire-probe.tar.gz \
     \
-# Install msgpack (for more efficient serialization in memcached)
-# @DEPRECATED @TODO Consider to be removed in v2 format version, atm igbinary (v2) is more widely supported.
-    && for i in $(seq 1 3); do pecl install -o msgpack && s=0 && break || s=$? && sleep 1; done; (exit $s) \
-    && docker-php-ext-enable msgpack \
-    \
 # Install igbinary (for more efficient serialization in redis/memcached)
     && for i in $(seq 1 3); do pecl install -o igbinary && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable igbinary \

--- a/php/Dockerfile-7.1
+++ b/php/Dockerfile-7.1
@@ -1,4 +1,4 @@
-FROM php:7.1-fpm
+FROM php:7.1-fpm-jessie
 
 # Container containing php-fpm and php-cli to run and interact with eZ Platform and other Symfony projects
 #
@@ -20,8 +20,8 @@ RUN apt-get update -q -y \
         libfreetype6 \
         libjpeg62-turbo \
         libxpm4 \
-        libpng16-16 \
-        libicu57 \
+        libpng12-0 \
+        libicu52 \
         libxslt1.1 \
         libmemcachedutil2 \
 # git & unzip needed for composer, unless we document to use dev image for composer install
@@ -37,7 +37,7 @@ RUN set -xe \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libxpm-dev \
-        libpng-dev \
+        libpng12-dev \
         libicu-dev \
         libxslt1-dev \
         libmemcached-dev \

--- a/php/Dockerfile-7.1
+++ b/php/Dockerfile-7.1
@@ -79,11 +79,18 @@ RUN set -xe \
     && cd - \
     \
 # Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)
-    && for i in $(seq 1 3); do echo no | pecl install -o memcached && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && for i in $(seq 1 3); do echo no | pecl install -o --nobuild memcached && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && cd "$(pecl config-get temp_dir)/memcached" \
+    && phpize \
+    && ./configure --enable-memcached-igbinary \
+    && make \
+    && make install \
     && docker-php-ext-enable memcached \
+    && cd - \
     \
 # Delete source & builds deps so it does not hang around in layers taking up space
     && pecl clear-cache \
+    && rm -Rf "$(pecl config-get temp_dir)/*" \
     && docker-php-source delete \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps
 

--- a/php/Dockerfile-7.1
+++ b/php/Dockerfile-7.1
@@ -11,7 +11,7 @@ ENV COMPOSER_HOME=/root/.composer
 
 # Get packages that we need in container
 RUN apt-get update -q -y \
-    && apt-get install -q -y --force-yes --no-install-recommends \
+    && apt-get install -q -y --no-install-recommends \
         ca-certificates \
         curl \
         acl \
@@ -20,8 +20,8 @@ RUN apt-get update -q -y \
         libfreetype6 \
         libjpeg62-turbo \
         libxpm4 \
-        libpng12-0 \
-        libicu52 \
+        libpng16-16 \
+        libicu57 \
         libxslt1.1 \
         libmemcachedutil2 \
 # git & unzip needed for composer, unless we document to use dev image for composer install
@@ -37,12 +37,12 @@ RUN set -xe \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libxpm-dev \
-        libpng12-dev \
+        libpng-dev \
         libicu-dev \
         libxslt1-dev \
         libmemcached-dev \
     " \
-	&& apt-get update && apt-get install -y --force-yes $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update -q -y && apt-get install -q -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
 # Extract php source and install missing extensions
     && docker-php-source extract \
     && docker-php-ext-configure mysqli --with-mysqli=mysqlnd \

--- a/php/Dockerfile-7.1
+++ b/php/Dockerfile-7.1
@@ -47,7 +47,7 @@ RUN set -xe \
     && docker-php-source extract \
     && docker-php-ext-configure mysqli --with-mysqli=mysqlnd \
     && docker-php-ext-configure pdo_mysql --with-pdo-mysql=mysqlnd \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ --with-xpm-dir=/usr/include/ --enable-gd-native-ttf --enable-gd-jis-conv \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ --with-xpm-dir=/usr/include/ --enable-gd-jis-conv \
     && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql \
     && docker-php-ext-enable opcache \
     && cp /usr/src/php/php.ini-production ${PHP_INI_DIR}/php.ini \
@@ -68,15 +68,22 @@ RUN set -xe \
     && for i in $(seq 1 3); do pecl install -o igbinary && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable igbinary \
     \
-# Install redis
-    && for i in $(seq 1 3); do pecl install -o --enable-redis-igbinary redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+# Install redis (manualy build in order to be able to enable igbinary)
+    && for i in $(seq 1 3); do pecl install -o --nobuild redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && cd "$(pecl config-get temp_dir)/redis" \
+    && phpize \
+    && ./configure --enable-redis-igbinary \
+    && make \
+    && make install \
     && docker-php-ext-enable redis \
+    && cd - \
     \
 # Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)
     && for i in $(seq 1 3); do echo no | pecl install -o memcached && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable memcached \
     \
 # Delete source & builds deps so it does not hang around in layers taking up space
+    && pecl clear-cache \
     && docker-php-source delete \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps
 

--- a/php/Dockerfile-7.1
+++ b/php/Dockerfile-7.1
@@ -69,7 +69,7 @@ RUN set -xe \
     && docker-php-ext-enable igbinary \
     \
 # Install redis
-    && for i in $(seq 1 3); do pecl install -o redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && for i in $(seq 1 3); do pecl install -o --enable-redis-igbinary redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable redis \
     \
 # Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)

--- a/php/Dockerfile-7.1
+++ b/php/Dockerfile-7.1
@@ -73,7 +73,7 @@ RUN set -xe \
     && docker-php-ext-enable redis \
     && cd - \
     \
-# Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)
+# Install memcached (manualy build in order to be able to enable igbinary)
     && for i in $(seq 1 3); do echo no | pecl install -o --nobuild memcached && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && cd "$(pecl config-get temp_dir)/memcached" \
     && phpize \

--- a/php/Dockerfile-7.1
+++ b/php/Dockerfile-7.1
@@ -59,9 +59,14 @@ RUN set -xe \
     && mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -f /tmp/blackfire-probe.tar.gz \
     \
-# Install msgpack (for more efficient serialization in redis/memcached)
+# Install msgpack (for more efficient serialization in memcached)
+# @DEPRECATED @TODO Consider to be removed in v2 format version, atm igbinary (v2) is more widely supported.
     && for i in $(seq 1 3); do pecl install -o msgpack && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable msgpack \
+    \
+# Install igbinary (for more efficient serialization in redis/memcached)
+    && for i in $(seq 1 3); do pecl install -o igbinary && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && docker-php-ext-enable igbinary \
     \
 # Install redis
     && for i in $(seq 1 3); do pecl install -o redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \

--- a/php/Dockerfile-7.2
+++ b/php/Dockerfile-7.2
@@ -59,11 +59,6 @@ RUN set -xe \
     && mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -f /tmp/blackfire-probe.tar.gz \
     \
-# Install msgpack (for more efficient serialization in memcached)
-# @DEPRECATED @TODO Consider to be removed in v2 format version, atm igbinary (v2) is more widely supported.
-    && for i in $(seq 1 3); do pecl install -o msgpack && s=0 && break || s=$? && sleep 1; done; (exit $s) \
-    && docker-php-ext-enable msgpack \
-    \
 # Install igbinary (for more efficient serialization in redis/memcached)
     && for i in $(seq 1 3); do pecl install -o igbinary && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable igbinary \

--- a/php/Dockerfile-7.2
+++ b/php/Dockerfile-7.2
@@ -79,11 +79,18 @@ RUN set -xe \
     && cd - \
     \
 # Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)
-    && for i in $(seq 1 3); do echo no | pecl install -o memcached && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && for i in $(seq 1 3); do echo no | pecl install -o --nobuild memcached && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && cd "$(pecl config-get temp_dir)/memcached" \
+    && phpize \
+    && ./configure --enable-memcached-igbinary \
+    && make \
+    && make install \
     && docker-php-ext-enable memcached \
+    && cd - \
     \
 # Delete source & builds deps so it does not hang around in layers taking up space
     && pecl clear-cache \
+    && rm -Rf "$(pecl config-get temp_dir)/*" \
     && docker-php-source delete \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps
 

--- a/php/Dockerfile-7.2
+++ b/php/Dockerfile-7.2
@@ -47,7 +47,7 @@ RUN set -xe \
     && docker-php-source extract \
     && docker-php-ext-configure mysqli --with-mysqli=mysqlnd \
     && docker-php-ext-configure pdo_mysql --with-pdo-mysql=mysqlnd \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ --with-xpm-dir=/usr/include/ --enable-gd-native-ttf --enable-gd-jis-conv \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/ --with-xpm-dir=/usr/include/ --enable-gd-jis-conv \
     && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql \
     && docker-php-ext-enable opcache \
     && cp /usr/src/php/php.ini-production ${PHP_INI_DIR}/php.ini \
@@ -68,15 +68,22 @@ RUN set -xe \
     && for i in $(seq 1 3); do pecl install -o igbinary && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable igbinary \
     \
-# Install redis
-    && for i in $(seq 1 3); do pecl install -o --enable-redis-igbinary redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+# Install redis (manualy build in order to be able to enable igbinary)
+    && for i in $(seq 1 3); do pecl install -o --nobuild redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && cd "$(pecl config-get temp_dir)/redis" \
+    && phpize \
+    && ./configure --enable-redis-igbinary \
+    && make \
+    && make install \
     && docker-php-ext-enable redis \
+    && cd - \
     \
 # Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)
     && for i in $(seq 1 3); do echo no | pecl install -o memcached && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable memcached \
     \
 # Delete source & builds deps so it does not hang around in layers taking up space
+    && pecl clear-cache \
     && docker-php-source delete \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps
 

--- a/php/Dockerfile-7.2
+++ b/php/Dockerfile-7.2
@@ -69,7 +69,7 @@ RUN set -xe \
     && docker-php-ext-enable igbinary \
     \
 # Install redis
-    && for i in $(seq 1 3); do pecl install -o redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && for i in $(seq 1 3); do pecl install -o --enable-redis-igbinary redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable redis \
     \
 # Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)

--- a/php/Dockerfile-7.2
+++ b/php/Dockerfile-7.2
@@ -73,7 +73,7 @@ RUN set -xe \
     && docker-php-ext-enable redis \
     && cd - \
     \
-# Install memcached (as we are on Debian 8 we have libmemcached 1.0.18 which is recommended)
+# Install memcached (manualy build in order to be able to enable igbinary)
     && for i in $(seq 1 3); do echo no | pecl install -o --nobuild memcached && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && cd "$(pecl config-get temp_dir)/memcached" \
     && phpize \

--- a/php/Dockerfile-7.2
+++ b/php/Dockerfile-7.2
@@ -59,9 +59,14 @@ RUN set -xe \
     && mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -f /tmp/blackfire-probe.tar.gz \
     \
-# Install msgpack (for more efficient serialization in redis/memcached)
+# Install msgpack (for more efficient serialization in memcached)
+# @DEPRECATED @TODO Consider to be removed in v2 format version, atm igbinary (v2) is more widely supported.
     && for i in $(seq 1 3); do pecl install -o msgpack && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable msgpack \
+    \
+# Install igbinary (for more efficient serialization in redis/memcached)
+    && for i in $(seq 1 3); do pecl install -o igbinary && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && docker-php-ext-enable igbinary \
     \
 # Install redis
     && for i in $(seq 1 3); do pecl install -o redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \

--- a/php/conf.d/php.ini
+++ b/php/conf.d/php.ini
@@ -31,3 +31,7 @@ opcache.max_wasted_percentage=10
 ; Implies no cache systems caching to php files and changing the file over the container lifecycle
 ;opcache.validate_timestamps=0
 ;opcache.enable_file_override=0
+
+; SESSION
+; Use igbinary for session serialization
+session.serialize_handler=igbinary


### PR DESCRIPTION
Replaces msgpack _(which has not been configured correctly for memecached as you can see in diff here, so in practice has never been possible to use. It also never supported PHP 5.x)_ with [igbinary](https://pecl.php.net/package/igbinary) which is now supported also on PHP 7, and which provides better packing / unpacking performance then msgpack with more or less comparable size of the serialized data.

_Note: This will notably also pull in newer versions of Composer (1.7), besides usual newer patch releases of PHP and pecl extensions incl recent security fixes._


Other changes:
- Update docker compose
- Adjust for upstream changes and specify -jessie for images that has been using that
- Doc updates
- Add additional calls to clear pecl cache and empty pecl temporary folder after builds to save some more space