### PR TITLE
Don't show php version to the world

### DIFF
--- a/php/conf.d/php.ini
+++ b/php/conf.d/php.ini
@@ -35,3 +35,6 @@ opcache.max_wasted_percentage=10
 ; SESSION
 ; Use igbinary for session serialization
 session.serialize_handler=igbinary
+
+; Don't show php version to the world
+expose_php = Off


### PR DESCRIPTION
Hides "X-Powered-By: PHP/x.x.xx" from a response header.