### PR TITLE
Increased PHP memory limit to 512M

### DIFF
--- a/php/conf.d/php.ini
+++ b/php/conf.d/php.ini
@@ -1,5 +1,5 @@
 ; Set defaults that should be enough for most normal use.
-memory_limit=256M
+memory_limit=512M
 max_execution_time=90
 
 ; Set timezone, uses UTC by default to make sure data is stored in universial time.


### PR DESCRIPTION
This PR is meant to start a discussion, I'm not really sure this is the best solution 😉 

Currently the repository-forms tests are failing on Travis:
https://travis-ci.com/ezsystems/ezplatform-page-builder/jobs/244043399
when run on ezplatform-ee-demo.

Error:
```
In ContainerBuilder.php line 1601:

                                                                                           
  [Symfony\Component\Debug\Exception\OutOfMemoryException]                                   

  Error: Allowed memory size of 268435456 bytes exhausted (tried to allocate 7344128 bytes) 
```

The events that are happening before that:
1) a Behat scenario sets Yaml config:
```
    Given a User Group
      And the following user registration group configuration:
      """
      ezpublish:
        system:
          default:
            user_registration:
              group_id: <userGroupContentId>
          site_group:
            user_registration:
              group_id: <userGroupContentId>
      """
```
(https://github.com/ezsystems/repository-forms/blob/2.5/features/User/Registration/user_registration.feature#L22)
2) This invokes YamlConfigurationContext from the Kernel: https://github.com/ezsystems/ezpublish-kernel/blob/7.5/eZ/Bundle/EzPublishCoreBundle/Features/Context/YamlConfigurationContext.php#L26 
which runs:
```
        $application = new Application($this->getKernel());
        $application->setAutoExit(false);
        $input = new ArrayInput([
            'command' => 'cache:clear',
        ]);
        $application->run($input);
```

trying to clear the cache so that the config is taken into account in next steps.

So, the issue is the tests are clearing the cache while Behat is running, which exceeds memory_limits.

Any idea what's the best way to approach it? 
- increasing the memory limit solves the problem (I've tested it locally)
- we could try to refactor the tests somehow, so that Behat and cache clearing command are not invoked at the same time (probably: introduce a "setup" stage on Travis that sets the config, then clears cache and then run the rest of tests). Not sure right now if it would help.
- something else completely? I'm not sure if the memory footprint from the command can be lowered.
