### PR TITLE
Changed Node version to 12 for v2 version of images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   global:
     - REMOTE_IMAGE="ezsystems/php"
     - LATEST="7.2"
-    - FORMAT_VERSION="v1"
+    - FORMAT_VERSION="v2"
   matrix:
     # Run once per Dockerfile-<PHP_VERSION>
     - PHP_VERSION="5.6" XDEBUG_CHANNEL="xdebug-2.5.5" EZ_VERSION="^1.13.4"

--- a/php/Dockerfile-node
+++ b/php/Dockerfile-node
@@ -3,7 +3,7 @@ FROM ez_php
 # Install Node.js and Yarn
 RUN apt-get update -q -y \
     && apt-get install -q -y --no-install-recommends gnupg \ 
-    && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+    && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
     && apt-get install -y nodejs \
     && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-31620

As suggested in discussion here: https://github.com/ezsystems/developer-documentation/pull/1012#discussion_r403894334 we should try running tests on Travis using Node 12.

It has been verified manually that this version works correctly with Platform 3.0: https://jira.ez.no/browse/EZP-31553

I'd like to keep both versions of Node available (10 and 12), so that we can use Node 10 to run tests on Platform 2.0 and Node 12 to run tests on Platform 3.0.

If I understand correctly this can be achieved by bumping the `FORMAT_VERSION` variable:
image `ezsystems/php:7.3-v1-node` will contain Node 10 (as it used to) and `ezsystems/php:7.3-v2-node` will contain Node 12.