### PR TITLE
Changed how the tag is versioned - from full Node version to major number only

### DIFF
--- a/bin/.travis/push.sh
+++ b/bin/.travis/push.sh
@@ -35,6 +35,7 @@ VERSION_FORMAT="$2"
 
 PHP_VERSION=`docker -l error run ez_php:latest php -r "echo PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION;"`
 NODE_VERSION=`docker -l error run ez_php:latest-node node -e "console.log(process.versions.node)"` 
+NODE_VERSION=`echo $NODE_VERSION | cut -f 1 -d "."`
 
 docker images
 docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"


### PR DESCRIPTION
After https://github.com/ezsystems/docker-php/pull/52 the new images are tagged:
https://hub.docker.com/r/ezsystems/php/tags

The tags look like this:
- `7.2-v2-node12.18.3`
- `7.2-v2-node10.22.0`
(...)

but IHMO they should look like this:
- `7.2-v2-node12`
- `7.2-v2-node10`

This PR fixes this formatting issue.

Q: Do we leave the created tags as they are or should we delete them from docker hub?