### PR TITLE
Added support for PostgreSQL in wait_for_db script

### DIFF
--- a/php/scripts/wait_for_db.php
+++ b/php/scripts/wait_for_db.php
@@ -22,8 +22,6 @@ $host = getenv('DATABASE_HOST') ?: (!empty($argv[1]) ? $argv[1] : 'db');
 $port = getenv('DATABASE_PORT');
 $name = getenv('DATABASE_NAME') ?: 'ezp';
 
-
-
 /**
  * Special handling for the different database drivers.
  *
@@ -38,10 +36,11 @@ if ($driver === 'sqlite') {
     $dsn = "sqlsrv:Server=${host}" . ($port ? ",${port}" : '') . ";Database=${name};";
 } else if ($driver === 'oci8') {
     $dsn = "oci:dbname=//${host}" . ($port ? ":${port}" : '') . "/${name};";
+} else if ($driver === "pdo_pgsql") {
+    $dsn = "pgsql:host=${host};" . ($port ? "port=${port};" : ''). "dbname=${name};";
 } else {
     $dsn = "${driver}:host=${host};" . ($port ? "port=${port};" : ''). "dbname=${name};";
 }
-
 
 /**
  * User credentials


### PR DESCRIPTION
Currently it's not possible to use PostgreSQL with our Travis setup, example build: https://travis-ci.org/github/ezsystems/ezplatform/jobs/714528668

The wait_for_db scripts cannot connect to the database:
```
Checking database is up, attempt: 1
Checking database is up, attempt: 2
Checking database is up, attempt: 3
Checking database is up, attempt: 4
Checking database is up, attempt: 5
Checking database is up, attempt: 6
Checking database is up, attempt: 7
Checking database is up, attempt: 8
Checking database is up, attempt: 9
Checking database is up, attempt: 10
Checking database is up, attempt: 11
Checking database is up, attempt: 12
Checking database is up, attempt: 13
Checking database is up, attempt: 14
Checking database is up, attempt: 15
Checking database is up, attempt: 16
Checking database is up, attempt: 17
Checking database is up, attempt: 18
Checking database is up, attempt: 19
Checking database is up, attempt: 20
Checking database is up, attempt: 21
Checking database is up, attempt: 22
Checking database is up, attempt: 23
Checking database is up, attempt: 24
ERROR: Max limit reached, not able to connect to pdo_pgsql 'ezp', exiting with error code.
```

It's because the $dsn value is incorrect for postgresql, currently we have:
- `pdo_pgsql:host=db;port=5432;dbname=ezp;`
should be:
- `pgsql:host=localhost;port=5432;dbname=testdb;user=bruce;password=mypass` (according to https://www.php.net/manual/en/ref.pdo-pgsql.connection.php)

This is enough to get the script working.