### PR TITLE
Fixed v1 branch build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ env:
     - FORMAT_VERSION="v1"
   matrix:
     # Run once per Dockerfile-<PHP_VERSION>
-    - PHP_VERSION="5.6" XDEBUG_CHANNEL="xdebug-2.5.5" EZ_VERSION="^1.13.4"
-    - PHP_VERSION="7.0" XDEBUG_CHANNEL="xdebug-2.8.1" EZ_VERSION="^1.13.4"
+    - PHP_VERSION="5.6" XDEBUG_CHANNEL="xdebug-2.5.5" EZ_VERSION="^1.13.4@rc"
+    - PHP_VERSION="7.0" XDEBUG_CHANNEL="xdebug-2.8.1" EZ_VERSION="^1.13.4@rc"
     - PHP_VERSION="7.1"
     - PHP_VERSION="7.2"
     - PHP_VERSION="7.3"

--- a/bin/.travis/test.sh
+++ b/bin/.travis/test.sh
@@ -96,15 +96,20 @@ docker run -ti --rm ez_php:latest-dev bash -c "php -v; php -m"
 printf "\Integration: Behat testing on ez_php:latest and ez_php:latest-dev with eZ Platform\n"
 cd volumes/ezplatform
 
-export COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/redis.yml:doc/docker/selenium.yml" SYMFONY_ENV="behat" SYMFONY_DEBUG="0" PHP_IMAGE="ez_php:latest" PHP_IMAGE_DEV="ez_php:latest-dev"
+export COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/redis.yml:doc/docker/selenium.yml" SYMFONY_ENV="behat" SYMFONY_DEBUG="0" 
 
 if [ -f doc/docker/install-dependencies.yml ]; then
+    # Use dev variant for installation as it contains mysqldump
+    export PHP_IMAGE="ez_php:latest-dev"
     docker-compose -f doc/docker/install-dependencies.yml -f doc/docker/install-database.yml up --abort-on-container-exit
+    export PHP_IMAGE="ez_php:latest"
 else
+    export PHP_IMAGE="ez_php:latest" PHP_IMAGE_DEV="ez_php:latest-dev"
     docker-compose -f doc/docker/install.yml up --abort-on-container-exit
 fi
 
 docker-compose up -d --build --force-recreate
+
 if [ -f bin/console ]; then
     echo '> Workaround for v2 test issues: Change ownership of files inside docker container'
     docker-compose exec app sh -c 'chown -R www-data:www-data /var/www'


### PR DESCRIPTION
The build for v1 branch is failing (https://travis-ci.com/github/ezsystems/docker-php/builds/201749301) because:
1) The latest stable release of v1.13 cannot be installed without manual intervention (Composer reports security vulnerabilities). I've switched to the RC where it's fixed.
2) eZ Platform v2 uses by default the v2 format of the images here (changed in https://github.com/ezsystems/ezplatform/pull/590) and the test variables need to be adjusted if v1 format is still to be used. Dev format needs to be used for installation because it's the only one that has mysqldump.

I want a green build to release a new version of v1 images with Composer 2 (so they are used with eZ Platform 1.13 on Travis) and we get more usage of Composer2 before releasing 1.13.6.