### PR TITLE
Switched build to test on 3.3 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ language: generic
 services:
   - docker
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 env:
   global:
     - REMOTE_IMAGE="ezsystems/php"
@@ -14,23 +18,24 @@ env:
     - FORMAT_VERSION="v2"
   matrix:
     # Run per Dockerfile-<PHP_VERSION>-<NODE_VERSION>
-    - PHP_VERSION="7.1" NODE_VERSION="10" EZ_VERSION="^2.5@dev"
-    - PHP_VERSION="7.1" NODE_VERSION="12" EZ_VERSION="^2.5@dev"
-    - PHP_VERSION="7.1" NODE_VERSION="14" EZ_VERSION="^2.5@dev"
-    - PHP_VERSION="7.2" NODE_VERSION="10" EZ_VERSION="^2.5@dev"
-    - PHP_VERSION="7.2" NODE_VERSION="12" EZ_VERSION="^2.5@dev"
-    - PHP_VERSION="7.2" NODE_VERSION="14" EZ_VERSION="^2.5@dev"
-    - PHP_VERSION="7.3" NODE_VERSION="10" UPDATE_PACKAGES="1"
-    - PHP_VERSION="7.3" NODE_VERSION="12" UPDATE_PACKAGES="1"
-    - PHP_VERSION="7.3" NODE_VERSION="14" UPDATE_PACKAGES="1"
-    # As builds are made with minimum supported PHP versions we need to force composer update for PHP 7.4 due to ocramius/proxy-manager
-    - PHP_VERSION="7.4" NODE_VERSION="10" UPDATE_PACKAGES="1"
-    - PHP_VERSION="7.4" NODE_VERSION="12" UPDATE_PACKAGES="1"
-    - PHP_VERSION="7.4" NODE_VERSION="14" UPDATE_PACKAGES="1"
+    - PHP_VERSION="7.1" NODE_VERSION="10" PRODUCT_VERSION="^2.5" TEST_CMD="bin/behat -v --profile=adminui --suite=richtext"
+    - PHP_VERSION="7.1" NODE_VERSION="12" PRODUCT_VERSION="^2.5" TEST_CMD="bin/behat -v --profile=adminui --suite=richtext"
+    - PHP_VERSION="7.1" NODE_VERSION="14" PRODUCT_VERSION="^2.5" TEST_CMD="bin/behat -v --profile=adminui --suite=richtext"
+    - PHP_VERSION="7.2" NODE_VERSION="10" PRODUCT_VERSION="^2.5" TEST_CMD="bin/behat -v --profile=adminui --suite=richtext"
+    - PHP_VERSION="7.2" NODE_VERSION="12" PRODUCT_VERSION="^2.5" TEST_CMD="bin/behat -v --profile=adminui --suite=richtext"
+    - PHP_VERSION="7.2" NODE_VERSION="14" PRODUCT_VERSION="^2.5" TEST_CMD="bin/behat -v --profile=adminui --suite=richtext"
+    - PHP_VERSION="7.3" NODE_VERSION="10" TEST_CMD="vendor/bin/behat -v --profile=adminui --suite=richtext --config=behat_ibexa_oss.yaml"
+    - PHP_VERSION="7.3" NODE_VERSION="12" TEST_CMD="vendor/bin/behat -v --profile=adminui --suite=richtext --config=behat_ibexa_oss.yaml"
+    - PHP_VERSION="7.3" NODE_VERSION="14" TEST_CMD="vendor/bin/behat -v --profile=adminui --suite=richtext --config=behat_ibexa_oss.yaml"
+    - PHP_VERSION="7.4" NODE_VERSION="10" TEST_CMD="vendor/bin/behat -v --profile=adminui --suite=richtext --config=behat_ibexa_oss.yaml"
+    - PHP_VERSION="7.4" NODE_VERSION="12" TEST_CMD="vendor/bin/behat -v --profile=adminui --suite=richtext --config=behat_ibexa_oss.yaml"
+    - PHP_VERSION="7.4" NODE_VERSION="14" TEST_CMD="vendor/bin/behat -v --profile=adminui --suite=richtext --config=behat_ibexa_oss.yaml"
 
 before_script:
   - if [ ! -d ~/.composer/ ] ; then mkdir ~/.composer/; fi
+  - if [[ -n "${DOCKER_PASSWORD_TEST}" ]]; then echo ${DOCKER_PASSWORD_TEST} | docker login -u ${DOCKER_USERNAME_TEST} --password-stdin ; fi
   - echo "{\"github-oauth\":{\"github.com\":\"d0285ed5c8644f30547572ead2ed897431c1fc09\"}}" > ~/.composer/auth.json
+  - if [ "$GITHUB_TOKEN" != "" ] ; then composer global config github-oauth.github.com $GITHUB_TOKEN ; fi
   - bin/.travis/update_docker.sh
   - bin/.travis/build.sh ${PHP_VERSION} ${NODE_VERSION}
 script: bin/.travis/test.sh

--- a/bin/.travis/push.sh
+++ b/bin/.travis/push.sh
@@ -38,7 +38,7 @@ NODE_VERSION=`docker -l error run ez_php:latest-node node -e "console.log(proces
 NODE_VERSION=`echo $NODE_VERSION | cut -f 1 -d "."`
 
 docker images
-docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
 
 ## TAGS
 echo "About to tag remote image '${REMOTE_IMAGE}' with php version '${PHP_VERSION}' and Node '${NODE_VERSION}'"

--- a/php/Dockerfile-7.1
+++ b/php/Dockerfile-7.1
@@ -69,7 +69,7 @@ RUN set -xe \
     && for i in $(seq 1 3); do pecl install -o imagick && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && docker-php-ext-enable imagick \
 # Install xdebug
-    && for i in $(seq 1 3); do echo yes | pecl install -o "xdebug" && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && for i in $(seq 1 3); do echo yes | pecl install -o "xdebug-2.9.8" && s=0 && break || s=$? && sleep 1; done; (exit $s) \
 # Install blackfire: https://blackfire.io/docs/integrations/docker
     && version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \


### PR DESCRIPTION
Failing build: https://travis-ci.com/github/ezsystems/docker-php/builds/226279329

Failures:
1) The 7.1 jobs are failing with error:
```
pecl/xdebug requires PHP (version >= 7.2.0, version <= 8.0.99), installed version is 7.1.33
```

I'm limiting the xdebug version used (it's the same that's present in the currently released images)

2) The 7.3 and 7.4 jobs are failing because they'are trying to setup 3.3 using metarepo.
I've switched them to use the oss-skeleton.
