### PR TITLE
Disabled flex recipes when installing BehatBundle

### DIFF
--- a/bin/.travis/test.sh
+++ b/bin/.travis/test.sh
@@ -69,7 +69,8 @@ if [ "$REUSE_VOLUME" = "0" ]; then
           composer create-project --no-progress --no-interaction ibexa/oss-skeleton /var/www $PRODUCT_VERSION --no-install &&
           composer require --prefer-dist ibexa/docker --no-install --no-scripts &&
           composer install &&
-          composer require ezsystems/behatbundle --no-scripts --no-plugins &&
+          composer require --dev phpunit/phpunit:^8.0 -W --no-scripts &&
+          composer require ezsystems/behatbundle:v8.3.0 --no-scripts --no-plugins &&
           composer recipes:install ezsystems/behatbundle --force"
     fi
 fi

--- a/bin/.travis/test.sh
+++ b/bin/.travis/test.sh
@@ -69,7 +69,7 @@ if [ "$REUSE_VOLUME" = "0" ]; then
           composer create-project --no-progress --no-interaction ibexa/oss-skeleton /var/www $PRODUCT_VERSION --no-install &&
           composer require --prefer-dist ibexa/docker --no-install --no-scripts &&
           composer install &&
-          composer require ezsystems/behatbundle --no-scripts
+          composer require ezsystems/behatbundle --no-scripts --no-plugins &&
           composer recipes:install ezsystems/behatbundle --force"
     fi
 fi


### PR DESCRIPTION
Previously it was enough to run `--no-scripts` to disable both Composer scripts and Symfony Flex.

This has changed in https://github.com/composer/composer/releases/tag/2.1.2 (included from now on in our Docker images) - you need to have an additional `--no-plugins` call to disable Flex.

The second commit: https://github.com/ezsystems/docker-php/pull/60/commits/761c400952a73f2abdc287ba0a8993f723d28334 is needed to have the build passing, we can revert it once 3.3.7 is tagged.