### PR TITLE
Solve OpenSSL & Let's Encrypt issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-sudo: required
-dist: trusty
-
-language: generic
+dist: focal
+language: php
+php:
+  - 7.4
 
 services:
   - docker
@@ -24,15 +24,15 @@ env:
     - PHP_VERSION="7.2" NODE_VERSION="10" PRODUCT_VERSION="^2.5" TEST_CMD="bin/behat -v --profile=adminui --suite=richtext"
     - PHP_VERSION="7.2" NODE_VERSION="12" PRODUCT_VERSION="^2.5" TEST_CMD="bin/behat -v --profile=adminui --suite=richtext"
     - PHP_VERSION="7.2" NODE_VERSION="14" PRODUCT_VERSION="^2.5" TEST_CMD="bin/behat -v --profile=adminui --suite=richtext"
-    - PHP_VERSION="7.3" NODE_VERSION="10" TEST_CMD="vendor/bin/behat -v --profile=adminui --suite=richtext --config=behat_ibexa_oss.yaml"
-    - PHP_VERSION="7.3" NODE_VERSION="12" TEST_CMD="vendor/bin/behat -v --profile=adminui --suite=richtext --config=behat_ibexa_oss.yaml"
-    - PHP_VERSION="7.3" NODE_VERSION="14" TEST_CMD="vendor/bin/behat -v --profile=adminui --suite=richtext --config=behat_ibexa_oss.yaml"
-    - PHP_VERSION="7.4" NODE_VERSION="10" TEST_CMD="vendor/bin/behat -v --profile=adminui --suite=richtext --config=behat_ibexa_oss.yaml"
-    - PHP_VERSION="7.4" NODE_VERSION="12" TEST_CMD="vendor/bin/behat -v --profile=adminui --suite=richtext --config=behat_ibexa_oss.yaml"
-    - PHP_VERSION="7.4" NODE_VERSION="14" TEST_CMD="vendor/bin/behat -v --profile=adminui --suite=richtext --config=behat_ibexa_oss.yaml"
+    - PHP_VERSION="7.3" NODE_VERSION="10" TEST_CMD="vendor/bin/behat -v --profile=browser --suite=admin-ui --tags=@richtext --config=behat_ibexa_oss.yaml"
+    - PHP_VERSION="7.3" NODE_VERSION="12" TEST_CMD="vendor/bin/behat -v --profile=browser --suite=admin-ui --tags=@richtext --config=behat_ibexa_oss.yaml"
+    - PHP_VERSION="7.3" NODE_VERSION="14" TEST_CMD="vendor/bin/behat -v --profile=browser --suite=admin-ui --tags=@richtext --config=behat_ibexa_oss.yaml"
+    - PHP_VERSION="7.4" NODE_VERSION="10" TEST_CMD="vendor/bin/behat -v --profile=browser --suite=admin-ui --tags=@richtext --config=behat_ibexa_oss.yaml"
+    - PHP_VERSION="7.4" NODE_VERSION="12" TEST_CMD="vendor/bin/behat -v --profile=browser --suite=admin-ui --tags=@richtext --config=behat_ibexa_oss.yaml"
+    - PHP_VERSION="7.4" NODE_VERSION="14" TEST_CMD="vendor/bin/behat -v --profile=browser --suite=admin-ui --tags=@richtext --config=behat_ibexa_oss.yaml"
 
 before_script:
-  - if [ ! -d ~/.composer/ ] ; then mkdir ~/.composer/; fi
+  - export COMPOSER_HOME=$(composer config --global home)
   - if [[ -n "${DOCKER_PASSWORD_TEST}" ]]; then echo ${DOCKER_PASSWORD_TEST} | docker login -u ${DOCKER_USERNAME_TEST} --password-stdin ; fi
   - echo "{\"github-oauth\":{\"github.com\":\"d0285ed5c8644f30547572ead2ed897431c1fc09\"}}" > ~/.composer/auth.json
   - if [ "$GITHUB_TOKEN" != "" ] ; then composer global config github-oauth.github.com $GITHUB_TOKEN ; fi

--- a/bin/.travis/test.sh
+++ b/bin/.travis/test.sh
@@ -66,11 +66,9 @@ if [ "$REUSE_VOLUME" = "0" ]; then
           ez_php:latest-node \
           bash -c "
           composer --version &&
-          composer create-project --no-progress --no-interaction ibexa/oss-skeleton /var/www $PRODUCT_VERSION --no-install &&
-          composer require --prefer-dist ibexa/docker --no-install --no-scripts &&
-          composer install &&
-          composer require --dev phpunit/phpunit:^8.0 -W --no-scripts &&
-          composer require ezsystems/behatbundle:v8.3.0 --no-scripts --no-plugins &&
+          composer create-project --no-progress --no-interaction ibexa/oss-skeleton /var/www $PRODUCT_VERSION &&
+          composer require ibexa/docker &&
+          composer require ezsystems/behatbundle:^8.3 --no-scripts --no-plugins &&
           composer recipes:install ezsystems/behatbundle --force"
     fi
 fi
@@ -94,12 +92,12 @@ export APP_ENV="behat" APP_DEBUG="1"
 export PHP_IMAGE="ez_php:latest-node" PHP_IMAGE_DEV="ez_php:latest-node"
 
 if [ "$PRODUCT_VERSION" = "^2.5" ]; then
-    docker-compose -f doc/docker/install-dependencies.yml -f doc/docker/install-database.yml up --abort-on-container-exit
-    docker-compose up -d --build --force-recreate
+    docker-compose --env-file .env -f doc/docker/install-dependencies.yml -f doc/docker/install-database.yml up --abort-on-container-exit
+    docker-compose --env-file .env up -d --build --force-recreate
     echo '> Workaround for test issues: Change ownership of files inside docker container'
     docker-compose exec app sh -c 'chown -R www-data:www-data /var/www'
 elif [ "$PRODUCT_VERSION" = "~3.3.0" ]; then
-    docker-compose up -d --build --force-recreate
+    docker-compose --env-file .env up -d --build --force-recreate
     echo '> Workaround for test issues: Change ownership of files inside docker container'
     docker-compose exec app sh -c 'chown -R www-data:www-data /var/www'
     # Rebuild Symfony container
@@ -113,4 +111,4 @@ fi
 
 docker-compose exec --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console cache:warmup; $TEST_CMD"
 
-docker-compose down -v
+docker-compose --env-file .env down -v

--- a/bin/.travis/update_docker.sh
+++ b/bin/.travis/update_docker.sh
@@ -12,7 +12,7 @@ docker -v
 
 
 docker-compose -v
-DOCKER_COMPOSE_VERSION="1.22.0"
+DOCKER_COMPOSE_VERSION="1.25.1"
 echo "\nUpdating Docker Compose to ${DOCKER_COMPOSE_VERSION}"
 sudo rm -f /usr/local/bin/docker-compose
 curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose

--- a/php/Dockerfile-7.1
+++ b/php/Dockerfile-7.1
@@ -16,9 +16,9 @@ RUN apt-get update -q -y \
         curl \
         acl \
         sudo \
-# Add expired Let's Encrypt certificate to the blacklist
-    && cp /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt /etc/pki/ca-trust/source/blacklist \
-    && update-ca-trust \
+# Disable expired Let's Encrypt certificate
+    && sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \
+    && update-ca-certificates --verbose \
 # Needed for the php extensions we enable below
     && apt-get install -q -y --no-install-recommends \
         libfreetype6 \

--- a/php/Dockerfile-7.1
+++ b/php/Dockerfile-7.1
@@ -16,7 +16,11 @@ RUN apt-get update -q -y \
         curl \
         acl \
         sudo \
+# Remove expired Let's Encrypt certificate
+    && rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt \
+    && update-ca-certificates \
 # Needed for the php extensions we enable below
+    && apt-get install -q -y --no-install-recommends \
         libfreetype6 \
         libjpeg62-turbo \
         libxpm4 \

--- a/php/Dockerfile-7.1
+++ b/php/Dockerfile-7.1
@@ -16,9 +16,9 @@ RUN apt-get update -q -y \
         curl \
         acl \
         sudo \
-# Remove expired Let's Encrypt certificate
-    && rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt \
-    && update-ca-certificates \
+# Add expired Let's Encrypt certificate to the blacklist
+    && cp /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt /etc/pki/ca-trust/source/blacklist \
+    && update-ca-trust \
 # Needed for the php extensions we enable below
     && apt-get install -q -y --no-install-recommends \
         libfreetype6 \

--- a/php/Dockerfile-7.2
+++ b/php/Dockerfile-7.2
@@ -16,9 +16,9 @@ RUN apt-get update -q -y \
         curl \
         acl \
         sudo \
-# Add expired Let's Encrypt certificate to the blacklist
-    && cp /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt /etc/pki/ca-trust/source/blacklist \
-    && update-ca-trust \
+# Disable expired Let's Encrypt certificate
+    && sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \
+    && update-ca-certificates --verbose \
 # Needed for the php extensions we enable below
     && apt-get install -q -y --no-install-recommends \
         libfreetype6 \

--- a/php/Dockerfile-7.2
+++ b/php/Dockerfile-7.2
@@ -16,7 +16,11 @@ RUN apt-get update -q -y \
         curl \
         acl \
         sudo \
+# Remove expired Let's Encrypt certificate
+    && rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt \
+    && update-ca-certificates \
 # Needed for the php extensions we enable below
+    && apt-get install -q -y --no-install-recommends \
         libfreetype6 \
         libjpeg62-turbo \
         libxpm4 \

--- a/php/Dockerfile-7.2
+++ b/php/Dockerfile-7.2
@@ -16,9 +16,9 @@ RUN apt-get update -q -y \
         curl \
         acl \
         sudo \
-# Remove expired Let's Encrypt certificate
-    && rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt \
-    && update-ca-certificates \
+# Add expired Let's Encrypt certificate to the blacklist
+    && cp /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt /etc/pki/ca-trust/source/blacklist \
+    && update-ca-trust \
 # Needed for the php extensions we enable below
     && apt-get install -q -y --no-install-recommends \
         libfreetype6 \

--- a/php/Dockerfile-7.3
+++ b/php/Dockerfile-7.3
@@ -16,9 +16,9 @@ RUN apt-get update -q -y \
         curl \
         acl \
         sudo \
-# Add expired Let's Encrypt certificate to the blacklist
-    && cp /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt /etc/pki/ca-trust/source/blacklist \
-    && update-ca-trust \
+# Disable expired Let's Encrypt certificate
+    && sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \
+    && update-ca-certificates --verbose \
 # Needed for the php extensions we enable below
     && apt-get install -q -y --no-install-recommends \
         libfreetype6 \

--- a/php/Dockerfile-7.3
+++ b/php/Dockerfile-7.3
@@ -16,7 +16,11 @@ RUN apt-get update -q -y \
         curl \
         acl \
         sudo \
+# Remove expired Let's Encrypt certificate
+    && rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt \
+    && update-ca-certificates \
 # Needed for the php extensions we enable below
+    && apt-get install -q -y --no-install-recommends \
         libfreetype6 \
         libjpeg62-turbo \
         libxpm4 \

--- a/php/Dockerfile-7.3
+++ b/php/Dockerfile-7.3
@@ -16,9 +16,9 @@ RUN apt-get update -q -y \
         curl \
         acl \
         sudo \
-# Remove expired Let's Encrypt certificate
-    && rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt \
-    && update-ca-certificates \
+# Add expired Let's Encrypt certificate to the blacklist
+    && cp /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt /etc/pki/ca-trust/source/blacklist \
+    && update-ca-trust \
 # Needed for the php extensions we enable below
     && apt-get install -q -y --no-install-recommends \
         libfreetype6 \

--- a/php/Dockerfile-7.4
+++ b/php/Dockerfile-7.4
@@ -16,9 +16,9 @@ RUN apt-get update -q -y \
         curl \
         acl \
         sudo \
-# Add expired Let's Encrypt certificate to the blacklist
-    && cp /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt /etc/pki/ca-trust/source/blacklist \
-    && update-ca-trust \
+# Disable expired Let's Encrypt certificate
+    && sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \
+    && update-ca-certificates --verbose \
 # Needed for the php extensions we enable below
     && apt-get install -q -y --no-install-recommends \
         libfreetype6 \

--- a/php/Dockerfile-7.4
+++ b/php/Dockerfile-7.4
@@ -16,7 +16,11 @@ RUN apt-get update -q -y \
         curl \
         acl \
         sudo \
+# Remove expired Let's Encrypt certificate
+    && rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt \
+    && update-ca-certificates \
 # Needed for the php extensions we enable below
+    && apt-get install -q -y --no-install-recommends \
         libfreetype6 \
         libjpeg62-turbo \
         libxpm4 \

--- a/php/Dockerfile-7.4
+++ b/php/Dockerfile-7.4
@@ -16,9 +16,9 @@ RUN apt-get update -q -y \
         curl \
         acl \
         sudo \
-# Remove expired Let's Encrypt certificate
-    && rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt \
-    && update-ca-certificates \
+# Add expired Let's Encrypt certificate to the blacklist
+    && cp /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt /etc/pki/ca-trust/source/blacklist \
+    && update-ca-trust \
 # Needed for the php extensions we enable below
     && apt-get install -q -y --no-install-recommends \
         libfreetype6 \


### PR DESCRIPTION
On 30.09.2021 the Let's Encrypt Root Certificate has expired. It does not play nicely with OpenSSL 1.0.2, which starts showing `SSL certificate problem: certificate has expired` errors everywhere.

You can find a more detailed write-up on [OpenSSL blog](https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/) and on [Let's encrypt blog](https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/).

Things done:
1) Upgraded dist from Trusty to Focal (Trusty uses OpenSSL 1.0.2, Focal has OpenSSL 1.1.1 which is not affected)
2) I was encountering GitHub API limits - I'm setting COMPOSE_HOME directly so that we don't have to rely on default values and auth.json is correctly shared between host and container
3) Docker Compose version has been updated
4) The expired certificates are removed so that even if OpenSSL 1.0.2 is used everything works correctly - it's the `Workaround 1 (on clients with OpenSSL 1.0.2)` from the OpenSSL blogpost.