### PR TITLE
Changed push script to push all tags

### DIFF
--- a/bin/.travis/push.sh
+++ b/bin/.travis/push.sh
@@ -61,4 +61,4 @@ if [ "$LATEST_PHP" = "$PHP_VERSION" ]; then
 fi
 
 echo "Pushing docker image with all tags : ${REMOTE_IMAGE}"
-docker push "${REMOTE_IMAGE}"
+docker push --all-tags "${REMOTE_IMAGE}"


### PR DESCRIPTION
Even though a PR has been merged to master and a build has been successful (https://app.travis-ci.com/github/ezsystems/docker-php/jobs/541098534) the new images have not been tagged:
https://hub.docker.com/r/ezsystems/php/tags?page=1&ordering=last_updated

It fails with:
```
Login Succeeded
About to tag remote image 'ezsystems/php' with php version '7.1' and Node '10'
Pushing docker image with all tags : ezsystems/php
Using default tag: latest
The push refers to repository [docker.io/ezsystems/php]
tag does not exist: ezsystems/php:latest
```

Updating dist (https://github.com/ezsystems/docker-php/pull/61) changed the Docker version.

Was:
```
[34m[1mdocker version[0m
Client:
 Version:      17.09.0-ce
 API version:  1.32
 Go version:   go1.8.3
 Git commit:   afdb6d4
 Built:        Tue Sep 26 22:42:38 2017
 OS/Arch:      linux/amd64

Server:
 Version:      17.09.0-ce
 API version:  1.32 (minimum version 1.12)
 Go version:   go1.8.3
 Git commit:   afdb6d4
 Built:        Tue Sep 26 22:41:20 2017
 OS/Arch:      linux/amd64
 Experimental: false
[34m[1mclang version[0m
clang version 5.0.0 (tags/RELEASE_500/final)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /usr/local/clang-5.0.0/bin
```

Now it's:
```
[34m[1mdocker version[0m
Client:
 Version:           20.10.2
 API version:       1.41
 Go version:        go1.13.8
 Git commit:        20.10.2-0ubuntu1~20.04.2
 Built:             Tue Mar 30 21:24:57 2021
 OS/Arch:           linux/amd64
 Context:           default
 Experimental:      true

Server:
 Engine:
  Version:          20.10.2
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.13.8
  Git commit:       20.10.2-0ubuntu1~20.04.2
  Built:            Mon Mar 29 19:10:09 2021
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.4.4-0ubuntu1~20.04.2
  GitCommit:        
 runc:
  Version:          1.0.0~rc95-0ubuntu1~20.04.1
  GitCommit:        
 docker-init:
  Version:          0.19.0
  GitCommit:   
```

Docker 20.10.0 had a breaking change ([ref](https://docs.docker.com/engine/release-notes/#runtime-3))
```
docker push now defaults to latest tag instead of all tags moby/moby#40302
```

The `--all-tags` option can be used to retain the old behaviour (https://docs.docker.com/engine/reference/commandline/push/#options)
